### PR TITLE
Add Ledger transaction signing and expand test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build/*
 node_modules
 broadcast/
 *.pyc
+.venv/
+uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 cache/
 transaction_builder/out/
 .env

--- a/transaction_signer/main.py
+++ b/transaction_signer/main.py
@@ -7,12 +7,12 @@ import src.eip712_typed_data as eip712_typed_data
 import src.safe_transaction as safe_transaction
 import src.tenderly as tenderly
 import src.user_input as user_input
+import src.utils.signatures as signatures
 import src.utils.validate_config as validate_config
 import src.utils.validate_signer as validate_signer
 
 from dotenv import load_dotenv, find_dotenv
 from eth_utils import keccak
-from json.decoder import JSONDecodeError
 from pathlib import Path
 from web3 import Web3
 
@@ -109,14 +109,11 @@ def _get_unsigned_safe_tx(relayer) -> dict | bool:
     signers_to_signatures = all_signatures.get(transaction_hash, {})
 
     # Sort the signatures in ascending order according to public addresses.
-    signers_and_signatures = list(signers_to_signatures.items())
-    signers_and_signatures.sort(key=lambda x: x[0])
+    signers_and_signatures = signatures.sort_by_signer(signers_to_signatures)
 
     # Only continue if threshold of safe is met.
     if len(signers_and_signatures) >= required_signatures:
-        signatures = "0x"
-        for _, signature in signers_and_signatures:
-            signatures += signature
+        packed_signatures = signatures.concatenate(signers_and_signatures)
 
         # Create the unsigned transaction:
         unsigned_safe_tx = safe_transaction.create(
@@ -126,7 +123,7 @@ def _get_unsigned_safe_tx(relayer) -> dict | bool:
             constants,
             raw_data,
             operation,
-            signatures,
+            packed_signatures,
             relayer["address"],
             gas,
             max_fee_per_gas,
@@ -207,7 +204,7 @@ if __name__ == "__main__":
     max_fee_per_gas = config_data["max_fee_per_gas"]
     max_priority_fee_per_gas = config_data["max_priority_fee_per_gas"]
 
-    validate_config.validate(safes, signers, relayers, operation, to)
+    validate_config.validate(safes, signers, relayers, operation, to, chains=chains)
 
     ### Constants ###
     constants = toml.load(os.path.join(path, "data/constants.toml"))
@@ -219,7 +216,12 @@ if __name__ == "__main__":
     # Select the Chain.
     chain = user_input.get_chain(chains)
     # Rpc provider.
-    w3 = Web3(Web3.HTTPProvider(os.getenv(chain["rpc_name"])))
+    rpc_url = os.getenv(chain["rpc_name"])
+    if not rpc_url:
+        raise Exception(
+            f"RPC URL environment variable '{chain['rpc_name']}' is not set."
+        )
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
     if w3.eth.chain_id != chain["chain_id"]:
         raise Exception(f"Chain Id is {w3.eth.chain_id}, expected {chain['chain_id']}")
 
@@ -255,11 +257,7 @@ if __name__ == "__main__":
     print(f"Transaction Hash is: {transaction_hash}")
 
     # Fetch the list of existing signatures, if it exists.
-    try:
-        with open(os.path.join(path, "out/signatures.txt")) as f:
-            all_signatures = json.load(f)
-    except JSONDecodeError:
-        all_signatures = {}
+    all_signatures = signatures.load(str(path))
 
     # Get existing signatures for the Transaction Hash.
     current_signers = list(all_signatures.get(transaction_hash, {}).keys())

--- a/transaction_signer/pyproject.toml
+++ b/transaction_signer/pyproject.toml
@@ -16,10 +16,14 @@ python-dotenv = "1.0.1"
 ledgerblue = "0.1.54"
 trezor = "0.13.9"
 web3 = "7.4.0"
-pip = "24.2"
 ipykernel = "6.29.5"
 ruff = "0.5.7"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/transaction_signer/src/eip712_typed_data.py
+++ b/transaction_signer/src/eip712_typed_data.py
@@ -103,7 +103,7 @@ def sign(
 
     else:
         input(
-            f'Signer {signer["name"]} ({signer["address"]}), please connect your Device and sign the data with wallet at index {signer["index"]}.\nPress Enter to continue...'
+            f"Signer {signer['name']} ({signer['address']}), please connect your Device and sign the data with wallet at index {signer['index']}.\nPress Enter to continue..."
         )
         # Sign Message.
         if signer["wallet"] == "T":

--- a/transaction_signer/src/safe_transaction.py
+++ b/transaction_signer/src/safe_transaction.py
@@ -1,6 +1,7 @@
 import os
 
 import src.wallets.hot_wallet as hot_wallet
+import src.wallets.ledger_nano as ledger_nano
 import src.wallets.trezor_1 as trezor_1
 import src.wallets.trezor_t as trezor_t
 
@@ -69,7 +70,7 @@ def sign(w3: any, unsigned_safe_tx: dict, relayer: dict) -> dict:
         )
     else:
         input(
-            f'Relayer {relayer["name"]} ({relayer["address"]}), please connect your Device and sign the transaction with wallet at index {relayer["index"]}.\nPress Enter to continue...'
+            f"Relayer {relayer['name']} ({relayer['address']}), please connect your Device and sign the transaction with wallet at index {relayer['index']}.\nPress Enter to continue..."
         )
         if relayer["wallet"] == "T":
             signed_tx = trezor_t.sign_transaction(
@@ -77,6 +78,10 @@ def sign(w3: any, unsigned_safe_tx: dict, relayer: dict) -> dict:
             )
         elif relayer["wallet"] == "1":
             signed_tx = trezor_1.sign_transaction(
+                relayer["index"], relayer["address"], unsigned_safe_tx
+            )
+        elif relayer["wallet"] == "L":
+            signed_tx = ledger_nano.sign_transaction(
                 relayer["index"], relayer["address"], unsigned_safe_tx
             )
         else:

--- a/transaction_signer/src/safe_transaction.py
+++ b/transaction_signer/src/safe_transaction.py
@@ -42,7 +42,8 @@ def create(
 
     # Use dynamic gas usage if 'gas' is set to 0 by the user.
     if gas == 0:
-        unsigned_safe_tx.update({"gas": int(w3.eth.estimate_gas(unsigned_safe_tx))})
+        estimated = int(w3.eth.estimate_gas(unsigned_safe_tx))
+        unsigned_safe_tx.update({"gas": int(estimated * 1.2)})
     else:
         unsigned_safe_tx.update({"gas": gas})
 

--- a/transaction_signer/src/tenderly.py
+++ b/transaction_signer/src/tenderly.py
@@ -51,10 +51,22 @@ def simulate(
         },
         "simulation_type": "quick",
     }
-    headers = {"X-Access-Key": os.getenv("TENDERLY_KEY")}
+    tenderly_key = os.getenv("TENDERLY_KEY")
+    if not tenderly_key:
+        raise Exception("TENDERLY_KEY environment variable is not set.")
+
+    headers = {"X-Access-Key": tenderly_key}
     url = tenderly_url + "/simulate"
     r = requests.post(url=url, json=body, headers=headers)
-    simulation_id = r.json()["simulation"]["id"]
+
+    if r.status_code != 200:
+        raise Exception(f"Tenderly simulation failed (HTTP {r.status_code}): {r.text}")
+
+    response = r.json()
+    if "simulation" not in response or "id" not in response["simulation"]:
+        raise Exception(f"Unexpected Tenderly response: {response}")
+
+    simulation_id = response["simulation"]["id"]
 
     # Make url public accessible.
     url = tenderly_url + f"/simulations/{simulation_id}/share"

--- a/transaction_signer/src/user_input.py
+++ b/transaction_signer/src/user_input.py
@@ -17,9 +17,8 @@ def get_chain(chains: list) -> dict:
     chain_id = int(answer.split("(Chain Id: ")[1].split(")")[0])
     for i in chains:
         if chain_id == i["chain_id"]:
-            chain = i
-            break
-    return chain
+            return i
+    raise ValueError(f"No chain found with chain_id {chain_id}")
 
 
 def get_safe(safes: list) -> dict:
@@ -38,9 +37,8 @@ def get_safe(safes: list) -> dict:
     safe_address = answer.split("(")[1].split(")")[0]
     for i in safes:
         if safe_address == i["address"]:
-            safe = i
-            break
-    return safe
+            return i
+    raise ValueError(f"No safe found with address {safe_address}")
 
 
 def get_signer(signers: list) -> dict | bool:
@@ -65,9 +63,8 @@ def get_signer(signers: list) -> dict | bool:
         signer_address = answer.split("(")[1].split(")")[0]
         for i in signers:
             if signer_address == i["address"]:
-                signer = i
-                break
-        return signer
+                return i
+        raise ValueError(f"No signer found with address {signer_address}")
 
 
 def get_relayer(relayers: list) -> dict | bool:
@@ -92,6 +89,5 @@ def get_relayer(relayers: list) -> dict | bool:
         relayer_address = answer.split("(")[1].split(")")[0]
         for i in relayers:
             if relayer_address == i["address"]:
-                relayer = i
-                break
-        return relayer
+                return i
+        raise ValueError(f"No relayer found with address {relayer_address}")

--- a/transaction_signer/src/utils/signatures.py
+++ b/transaction_signer/src/utils/signatures.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+from json.decoder import JSONDecodeError
+
+
+def sort_by_signer(signers_to_signatures: dict) -> list:
+    items = list(signers_to_signatures.items())
+    items.sort(key=lambda x: int(x[0], 16))
+    return items
+
+
+def load(path: str) -> dict:
+    try:
+        with open(os.path.join(path, "out/signatures.txt")) as f:
+            data = json.load(f)
+    except (JSONDecodeError, FileNotFoundError):
+        return {}
+
+    if not isinstance(data, dict):
+        raise TypeError(f"Expected dict in signatures file, got {type(data).__name__}")
+    return data
+
+
+def concatenate(signers_and_signatures: list) -> str:
+    result = "0x"
+    for _, signature in signers_and_signatures:
+        result += signature
+    return result

--- a/transaction_signer/src/utils/validate_config.py
+++ b/transaction_signer/src/utils/validate_config.py
@@ -1,4 +1,20 @@
-def validate(safes: dict, signers: dict, relayers: dict, operation: int, to: str):
+VALID_WALLET_TYPES = {"HOT", "T", "1", "L"}
+
+
+def validate(
+    safes: dict,
+    signers: dict,
+    relayers: dict,
+    operation: int,
+    to: str,
+    chains: list | None = None,
+):
+    if chains is not None:
+        for chain in chains:
+            name = chain["name"]
+            if name.find("(") >= 0 or name.find(")") >= 0:
+                raise Exception("Name can't contain characters '(' or ').")
+
     # Safe Name can't contain certain characters.
     for safe in safes:
         name = safe["name"]
@@ -19,6 +35,13 @@ def validate(safes: dict, signers: dict, relayers: dict, operation: int, to: str
         if name.find("(") >= 0 or name.find(")") >= 0:
             raise Exception("Name can't contain characters '(' or ').")
 
+        wallet = signer.get("wallet")
+        if wallet not in VALID_WALLET_TYPES:
+            raise Exception(
+                f"Invalid wallet type '{wallet}' for signer '{name}'. Must be one of {sorted(VALID_WALLET_TYPES)}."
+            )
+        _validate_wallet_fields(signer)
+
         addresses.append(signer["address"])
 
     # All signers must be unique.
@@ -32,8 +55,28 @@ def validate(safes: dict, signers: dict, relayers: dict, operation: int, to: str
         if name.find("(") >= 0 or name.find(")") >= 0:
             raise Exception("Name can't contain characters '(' or ').")
 
+        wallet = relayer.get("wallet")
+        if wallet not in VALID_WALLET_TYPES:
+            raise Exception(
+                f"Invalid wallet type '{wallet}' for relayer '{name}'. Must be one of {sorted(VALID_WALLET_TYPES)}."
+            )
+        _validate_wallet_fields(relayer)
+
         addresses.append(relayer["address"])
 
-    # All signers must be unique.
+    # All relayers must be unique.
     if len(addresses) != len(set(addresses)):
         raise Exception("All relayer addresses must be unique.")
+
+
+def _validate_wallet_fields(entry: dict):
+    wallet = entry["wallet"]
+    name = entry["name"]
+    if wallet == "HOT":
+        if "key_name" not in entry:
+            raise Exception(f"HOT wallet '{name}' must have a 'key_name' field.")
+    else:
+        if "index" not in entry:
+            raise Exception(
+                f"Hardware wallet '{name}' (type '{wallet}') must have an 'index' field."
+            )

--- a/transaction_signer/src/utils/validate_signer.py
+++ b/transaction_signer/src/utils/validate_signer.py
@@ -23,7 +23,7 @@ def validate(
 
     else:
         print(
-            f'Signer {signer["name"]} ({signer["address"]}) is not an owner of the safe {safe.address}.'
+            f"Signer {signer['name']} ({signer['address']}) is not an owner of the safe {safe.address}."
         )
     # Return False if not successful.
     return False

--- a/transaction_signer/src/wallets/hot_wallet.py
+++ b/transaction_signer/src/wallets/hot_wallet.py
@@ -13,7 +13,7 @@ def sign_typed_data(signer_key: str, signer_address: str, w3: any, data: dict) -
     """
 
     address = w3.eth.account.from_key(signer_key).address
-    if address != signer_address:
+    if address.lower() != signer_address.lower():
         print(
             f"Signer Address ({signer_address}) does not match address from private key ({address})"
         )
@@ -38,7 +38,7 @@ def sign_transaction(
     """
 
     address = w3.eth.account.from_key(signer_key).address
-    if address != signer_address:
+    if address.lower() != signer_address.lower():
         print(
             f"Signer Address ({signer_address}) does not match address from private key ({address})"
         )

--- a/transaction_signer/src/wallets/ledger_nano.py
+++ b/transaction_signer/src/wallets/ledger_nano.py
@@ -27,7 +27,7 @@ def sign_typed_data_hash(
 
     # Connect Ledger.
     try:
-        dongle = getDongle(True)
+        dongle = getDongle(False)
     except CommException as e:
         print(f"Error communicating with Ledger device: {e}")
         return None
@@ -35,7 +35,7 @@ def sign_typed_data_hash(
     # Verify that the given public address matches the address at the BIP32 path.
     try:
         address = get_address(dongle, dongle_path)
-        if address != signer_address:
+        if address.lower() != signer_address.lower():
             dongle.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
@@ -87,7 +87,7 @@ def sign_transaction(
 
     # Connect Ledger.
     try:
-        dongle = getDongle(True)
+        dongle = getDongle(False)
     except CommException as e:
         print(f"Error communicating with Ledger device: {e}")
         return None
@@ -95,7 +95,7 @@ def sign_transaction(
     # Verify that the given public address matches the address at the BIP32 path.
     try:
         address = get_address(dongle, dongle_path)
-        if address != signer_address:
+        if address.lower() != signer_address.lower():
             dongle.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
@@ -130,8 +130,8 @@ def sign_transaction(
                     to_bytes(hexstr=unsigned_safe_tx["data"]),
                     [],  # Access list
                     v,
-                    r,
-                    s,
+                    int.from_bytes(r, "big"),
+                    int.from_bytes(s, "big"),
                 ],
                 sedes=None,
             ).hex()

--- a/transaction_signer/src/wallets/ledger_nano.py
+++ b/transaction_signer/src/wallets/ledger_nano.py
@@ -1,7 +1,11 @@
+import rlp
 import struct
 
+from eth_utils import keccak, to_bytes
+from hexbytes import HexBytes
 from ledgerblue.comm import getDongle
 from ledgerblue.commException import CommException
+from web3.datastructures import AttributeDict
 
 
 def sign_typed_data_hash(
@@ -32,6 +36,7 @@ def sign_typed_data_hash(
     try:
         address = get_address(dongle, dongle_path)
         if address != signer_address:
+            dongle.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
             )
@@ -54,6 +59,94 @@ def sign_typed_data_hash(
         )
         dongle.close()
         return signature.hex()
+    except CommException as e:
+        dongle.close()
+        print(f"Error communicating with Ledger device: {e}")
+        return None
+    except Exception as e:
+        dongle.close()
+        print(f"Unexpected error: {e}")
+        return None
+
+
+def sign_transaction(
+    signer_index: int, signer_address: str, unsigned_safe_tx: dict
+) -> str:
+    """
+    Sign an Ethereum transaction using a Ledger device.
+
+    :param signer_index: The index of the BIP32 path of the Ethereum address used for signing.
+    :param signer_address: The public address of the signer.
+    :param unsigned_safe_tx: The unsigned transaction to sign.
+    :return: the signed transaction.
+    """
+
+    # Parse Dongle Path.
+    path = get_path(signer_index)
+    dongle_path = parse_bip32_path(path)
+
+    # Connect Ledger.
+    try:
+        dongle = getDongle(True)
+    except CommException as e:
+        print(f"Error communicating with Ledger device: {e}")
+        return None
+
+    # Verify that the given public address matches the address at the BIP32 path.
+    try:
+        address = get_address(dongle, dongle_path)
+        if address != signer_address:
+            dongle.close()
+            print(
+                f"Address at given index ({address}) does not match signers address ({signer_address})"
+            )
+            return None
+    except CommException as e:
+        dongle.close()
+        print(f"Error communicating with Ledger device: {e}")
+        return None
+    except Exception as e:
+        dongle.close()
+        print(f"Unexpected error: {e}")
+        return None
+
+    # Sign transaction.
+    try:
+        (v, r, s) = _sign_transaction(dongle, dongle_path, unsigned_safe_tx)
+        dongle.close()
+
+        # RLP encoding
+        signed_raw_tx = HexBytes(
+            "0x02"
+            + rlp.encode(
+                [
+                    unsigned_safe_tx["chainId"],
+                    unsigned_safe_tx["nonce"],
+                    unsigned_safe_tx["maxPriorityFeePerGas"],
+                    unsigned_safe_tx["maxFeePerGas"],
+                    unsigned_safe_tx["gas"],
+                    to_bytes(hexstr=unsigned_safe_tx["to"]),
+                    unsigned_safe_tx["value"],
+                    to_bytes(hexstr=unsigned_safe_tx["data"]),
+                    [],  # Access list
+                    v,
+                    r,
+                    s,
+                ],
+                sedes=None,
+            ).hex()
+        )
+
+        signed_tx = AttributeDict(
+            {
+                "raw_transaction": signed_raw_tx,
+                "hash": HexBytes(keccak(signed_raw_tx)),
+                "r": int.from_bytes(r, "big"),
+                "s": int.from_bytes(s, "big"),
+                "v": v,
+            }
+        )
+        return signed_tx
     except CommException as e:
         dongle.close()
         print(f"Error communicating with Ledger device: {e}")
@@ -131,3 +224,48 @@ def _sign_typed_data_hash(
 
     signature = r + s + v
     return signature
+
+
+def _sign_transaction(dongle: any, dongle_path: bytes, unsigned_safe_tx: dict) -> tuple:
+    # RLP-encode the unsigned EIP-1559 transaction.
+    encoded_tx = rlp.encode(
+        [
+            unsigned_safe_tx["chainId"],
+            unsigned_safe_tx["nonce"],
+            unsigned_safe_tx["maxPriorityFeePerGas"],
+            unsigned_safe_tx["maxFeePerGas"],
+            unsigned_safe_tx["gas"],
+            to_bytes(hexstr=unsigned_safe_tx["to"]),
+            unsigned_safe_tx["value"],
+            to_bytes(hexstr=unsigned_safe_tx["data"]),
+            [],
+        ],
+        sedes=None,
+    )
+    # EIP-1559 tx type prefix.
+    payload = b"\x02" + encoded_tx
+
+    # First chunk includes the BIP32 path.
+    path_len = len(dongle_path) // 4
+    first_chunk = bytes([path_len]) + dongle_path + payload
+    chunks = [first_chunk]
+
+    # The Ledger Ethereum app accepts up to 255 bytes per APDU payload.
+    while len(chunks[-1]) > 255:
+        oversized = chunks.pop()
+        chunks.append(oversized[:255])
+        chunks.append(oversized[255:])
+
+    result = None
+    for i, chunk in enumerate(chunks):
+        # P1: 0x00 for first chunk, 0x80 for subsequent chunks.
+        p1 = 0x00 if i == 0 else 0x80
+        apdu = bytearray.fromhex("e004") + bytes([p1, 0x02])
+        apdu.append(len(chunk))
+        apdu += chunk
+        result = dongle.exchange(bytes(apdu))
+
+    v = result[0]
+    r = bytes(result[1 : 1 + 32])
+    s = bytes(result[1 + 32 : 1 + 64])
+    return (v, r, s)

--- a/transaction_signer/src/wallets/trezor_1.py
+++ b/transaction_signer/src/wallets/trezor_1.py
@@ -37,7 +37,7 @@ def sign_typed_data_hash(
     # Verify that the given public address matches the address at the BIP32 path.
     try:
         address = ethereum.get_address(client=client, n=bip32_path)
-        if address != signer_address:
+        if address.lower() != signer_address.lower():
             client.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
@@ -90,7 +90,7 @@ def sign_transaction(
     # Verify that the given public address matches the address at the BIP32 path.
     try:
         address = ethereum.get_address(client=client, n=bip32_path)
-        if address != signer_address:
+        if address.lower() != signer_address.lower():
             client.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
@@ -132,8 +132,8 @@ def sign_transaction(
                     to_bytes(hexstr=unsigned_safe_tx["data"]),
                     [],  # Access list
                     v,
-                    r,
-                    s,
+                    int.from_bytes(r, "big"),
+                    int.from_bytes(s, "big"),
                 ],
                 sedes=None,
             ).hex()

--- a/transaction_signer/src/wallets/trezor_1.py
+++ b/transaction_signer/src/wallets/trezor_1.py
@@ -38,6 +38,7 @@ def sign_typed_data_hash(
     try:
         address = ethereum.get_address(client=client, n=bip32_path)
         if address != signer_address:
+            client.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
             )
@@ -90,6 +91,7 @@ def sign_transaction(
     try:
         address = ethereum.get_address(client=client, n=bip32_path)
         if address != signer_address:
+            client.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
             )

--- a/transaction_signer/src/wallets/trezor_t.py
+++ b/transaction_signer/src/wallets/trezor_t.py
@@ -34,7 +34,7 @@ def sign_typed_data(signer_index: int, signer_address: str, data: dict) -> str:
     # Verify that the given public address matches the address at the BIP32 path.
     try:
         address = ethereum.get_address(client=client, n=bip32_path)
-        if address != signer_address:
+        if address.lower() != signer_address.lower():
             client.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
@@ -82,7 +82,7 @@ def sign_transaction(
     # Verify that the given public address matches the address at the BIP32 path.
     try:
         address = ethereum.get_address(client=client, n=bip32_path)
-        if address != signer_address:
+        if address.lower() != signer_address.lower():
             client.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
@@ -124,8 +124,8 @@ def sign_transaction(
                     to_bytes(hexstr=unsigned_safe_tx["data"]),
                     [],  # Access list
                     v,
-                    r,
-                    s,
+                    int.from_bytes(r, "big"),
+                    int.from_bytes(s, "big"),
                 ],
                 sedes=None,
             ).hex()

--- a/transaction_signer/src/wallets/trezor_t.py
+++ b/transaction_signer/src/wallets/trezor_t.py
@@ -35,6 +35,7 @@ def sign_typed_data(signer_index: int, signer_address: str, data: dict) -> str:
     try:
         address = ethereum.get_address(client=client, n=bip32_path)
         if address != signer_address:
+            client.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
             )
@@ -82,6 +83,7 @@ def sign_transaction(
     try:
         address = ethereum.get_address(client=client, n=bip32_path)
         if address != signer_address:
+            client.close()
             print(
                 f"Address at given index ({address}) does not match signers address ({signer_address})"
             )

--- a/transaction_signer/tests/conftest.py
+++ b/transaction_signer/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+_tests_dir = os.path.dirname(__file__)
+_project_dir = os.path.join(_tests_dir, "..")
+
+sys.path.insert(0, _project_dir)
+sys.path.insert(0, _tests_dir)

--- a/transaction_signer/tests/helpers.py
+++ b/transaction_signer/tests/helpers.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock
+
+SAFE_TX_CONSTANTS = {
+    "VALUE_SAFE_TX": 0,
+    "SAFE_TX_GAS": 0,
+    "BASE_GAS": 0,
+    "GAS_PRICE": 0,
+    "GAS_TOKEN": "0x0000000000000000000000000000000000000000",
+    "REFUND_RECEIVER": "0x0000000000000000000000000000000000000000",
+}
+
+RELAY_TX_CONSTANTS = {
+    **SAFE_TX_CONSTANTS,
+    "VALUE_RELAY_TX": 0,
+}
+
+MULTISEND_ADDRESS = "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B"
+
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+HW_SIGNER_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+
+HW_DOMAIN_HASH = b"\x01" * 32
+HW_MESSAGE_HASH = b"\x02" * 32
+
+HW_UNSIGNED_TX = {
+    "to": MULTISEND_ADDRESS,
+    "value": 0,
+    "gas": 100000,
+    "nonce": 0,
+    "chainId": 8453,
+    "data": "0x1234",
+    "maxFeePerGas": 1000000000,
+    "maxPriorityFeePerGas": 1000000,
+}
+
+TYPED_DATA_TEMPLATE = {
+    "types": {
+        "EIP712Domain": [
+            {"name": "chainId", "type": "uint256"},
+            {"name": "verifyingContract", "type": "address"},
+        ],
+        "SafeTx": [
+            {"name": "to", "type": "address"},
+            {"name": "value", "type": "uint256"},
+            {"name": "data", "type": "bytes"},
+            {"name": "operation", "type": "uint8"},
+            {"name": "safeTxGas", "type": "uint256"},
+            {"name": "baseGas", "type": "uint256"},
+            {"name": "gasPrice", "type": "uint256"},
+            {"name": "gasToken", "type": "address"},
+            {"name": "refundReceiver", "type": "address"},
+            {"name": "nonce", "type": "uint256"},
+        ],
+    },
+    "primaryType": "SafeTx",
+}
+
+
+def make_typed_data(
+    to=MULTISEND_ADDRESS,
+    nonce=0,
+    operation=1,
+    data="0x1234",
+    chain_id=8453,
+    verifying_contract="0x1111111111111111111111111111111111111111",
+):
+    return {
+        **TYPED_DATA_TEMPLATE,
+        "message": {
+            "to": to,
+            "value": 0,
+            "data": data,
+            "operation": operation,
+            "safeTxGas": 0,
+            "baseGas": 0,
+            "gasPrice": 0,
+            "gasToken": ZERO_ADDRESS,
+            "refundReceiver": ZERO_ADDRESS,
+            "nonce": nonce,
+        },
+        "domain": {
+            "chainId": chain_id,
+            "verifyingContract": verifying_contract,
+        },
+    }
+
+
+def make_mock_safe(
+    nonce=0,
+    chain_id=8453,
+    address="0x1111111111111111111111111111111111111111",
+    is_owner=True,
+    owners=None,
+):
+    safe = MagicMock()
+    safe.functions.nonce.return_value.call.return_value = nonce
+    safe.functions.getChainId.return_value.call.return_value = chain_id
+    safe.functions.isOwner.return_value.call.return_value = is_owner
+    safe.functions.getOwners.return_value.call.return_value = owners or [
+        "0x2222222222222222222222222222222222222222"
+    ]
+    safe.functions.execTransaction.return_value.build_transaction.return_value = {
+        "nonce": 0,
+        "value": 0,
+        "chainId": chain_id,
+        "data": "0xabcdef",
+        "to": address,
+    }
+    safe.address = address
+    return safe

--- a/transaction_signer/tests/test_eip712_typed_data.py
+++ b/transaction_signer/tests/test_eip712_typed_data.py
@@ -4,14 +4,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from eth_abi import encode
 from eth_utils import keccak
-from web3 import Web3
-
 from helpers import SAFE_TX_CONSTANTS, make_mock_safe, make_typed_data
 from src.eip712_typed_data import get_typed_data, get_typed_data_hash, sign
 
-SAFE_TX_TYPEHASH = Web3.to_bytes(
-    hexstr="0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8"
-)
+SAFE_TX_TYPE_STRING = "SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
+SAFE_TX_TYPEHASH = keccak(text=SAFE_TX_TYPE_STRING)
 
 TO = "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B"
 RAW_DATA = "0x1234"

--- a/transaction_signer/tests/test_eip712_typed_data.py
+++ b/transaction_signer/tests/test_eip712_typed_data.py
@@ -1,0 +1,269 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from eth_abi import encode
+from eth_utils import keccak
+from web3 import Web3
+
+from helpers import SAFE_TX_CONSTANTS, make_mock_safe, make_typed_data
+from src.eip712_typed_data import get_typed_data, get_typed_data_hash, sign
+
+SAFE_TX_TYPEHASH = Web3.to_bytes(
+    hexstr="0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8"
+)
+
+TO = "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B"
+RAW_DATA = "0x1234"
+
+
+class TestGetTypedData:
+    def test_populates_all_fields(self):
+        safe = make_mock_safe(nonce=5, chain_id=8453)
+        result = get_typed_data(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS)
+
+        assert result["primaryType"] == "SafeTx"
+        assert result["message"]["to"] == TO
+        assert result["message"]["data"] == RAW_DATA
+        assert result["message"]["operation"] == 1
+        assert result["message"]["nonce"] == 5
+        assert result["domain"]["chainId"] == 8453
+        assert result["domain"]["verifyingContract"] == safe.address
+
+    def test_uses_constants(self):
+        safe = make_mock_safe()
+        result = get_typed_data(safe, TO, RAW_DATA, 0, SAFE_TX_CONSTANTS)
+
+        assert result["message"]["value"] == SAFE_TX_CONSTANTS["VALUE_SAFE_TX"]
+        assert result["message"]["safeTxGas"] == SAFE_TX_CONSTANTS["SAFE_TX_GAS"]
+        assert result["message"]["gasToken"] == SAFE_TX_CONSTANTS["GAS_TOKEN"]
+        assert (
+            result["message"]["refundReceiver"] == SAFE_TX_CONSTANTS["REFUND_RECEIVER"]
+        )
+
+    def test_calls_safe_contract(self):
+        safe = make_mock_safe()
+        get_typed_data(safe, TO, RAW_DATA, 0, SAFE_TX_CONSTANTS)
+
+        safe.functions.nonce.assert_called_once()
+        safe.functions.getChainId.assert_called_once()
+
+    def test_missing_constant_key_raises(self):
+        safe = make_mock_safe()
+        incomplete = {k: v for k, v in SAFE_TX_CONSTANTS.items() if k != "GAS_TOKEN"}
+        with pytest.raises(KeyError):
+            get_typed_data(safe, TO, RAW_DATA, 0, incomplete)
+
+    def test_nonce_call_failure_propagates(self):
+        safe = make_mock_safe()
+        safe.functions.nonce.return_value.call.side_effect = Exception("RPC error")
+        with pytest.raises(Exception, match="RPC error"):
+            get_typed_data(safe, TO, RAW_DATA, 0, SAFE_TX_CONSTANTS)
+
+    def test_chain_id_call_failure_propagates(self):
+        safe = make_mock_safe()
+        safe.functions.getChainId.return_value.call.side_effect = Exception("RPC error")
+        with pytest.raises(Exception, match="RPC error"):
+            get_typed_data(safe, TO, RAW_DATA, 0, SAFE_TX_CONSTANTS)
+
+
+class TestGetTypedDataHash:
+    def test_deterministic(self):
+        data = make_typed_data()
+        hash1 = get_typed_data_hash(data)
+        hash2 = get_typed_data_hash(data)
+        assert hash1 == hash2
+
+    def test_returns_32_bytes(self):
+        data = make_typed_data()
+        result = get_typed_data_hash(data)
+        assert len(result) == 32
+
+    def test_different_nonce_different_hash(self):
+        data1 = make_typed_data(nonce=0)
+        data2 = make_typed_data(nonce=1)
+        assert get_typed_data_hash(data1) != get_typed_data_hash(data2)
+
+    def test_different_data_different_hash(self):
+        data1 = make_typed_data()
+        data2 = make_typed_data(data="0xdeadbeef")
+        assert get_typed_data_hash(data1) != get_typed_data_hash(data2)
+
+    def test_matches_manual_computation(self):
+        data = make_typed_data()
+        expected = keccak(
+            encode(
+                [
+                    "bytes32",
+                    "address",
+                    "uint256",
+                    "bytes32",
+                    "uint8",
+                    "uint256",
+                    "uint256",
+                    "uint256",
+                    "address",
+                    "address",
+                    "uint256",
+                ],
+                [
+                    SAFE_TX_TYPEHASH,
+                    TO,
+                    0,
+                    keccak(hexstr=RAW_DATA),
+                    1,
+                    0,
+                    0,
+                    0,
+                    "0x0000000000000000000000000000000000000000",
+                    "0x0000000000000000000000000000000000000000",
+                    0,
+                ],
+            )
+        )
+        assert get_typed_data_hash(data) == expected
+
+    def test_missing_message_field_raises(self):
+        data = make_typed_data()
+        del data["message"]["nonce"]
+        with pytest.raises(KeyError):
+            get_typed_data_hash(data)
+
+    def test_invalid_hex_data_raises(self):
+        data = make_typed_data()
+        data["message"]["data"] = "not_hex"
+        with pytest.raises(Exception):
+            get_typed_data_hash(data)
+
+    def test_different_operation_different_hash(self):
+        data1 = make_typed_data(operation=0)
+        data2 = make_typed_data(operation=1)
+        assert get_typed_data_hash(data1) != get_typed_data_hash(data2)
+
+    def test_different_to_different_hash(self):
+        data1 = make_typed_data()
+        data2 = make_typed_data(to="0x0000000000000000000000000000000000000001")
+        assert get_typed_data_hash(data1) != get_typed_data_hash(data2)
+
+
+class TestSignRouting:
+    def test_hot_wallet_missing_key_returns_false(self):
+        signer = {
+            "name": "Test",
+            "address": "0x1234",
+            "wallet": "HOT",
+            "key_name": "NONEXISTENT_KEY",
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            result = sign(MagicMock(), signer, {}, b"", b"")
+        assert result is False
+
+    @patch("src.eip712_typed_data.hot_wallet.sign_typed_data")
+    def test_hot_wallet_with_key_calls_hot_wallet(self, mock_sign):
+        mock_sign.return_value = "0xsig"
+        signer = {
+            "name": "Test",
+            "address": "0x1234",
+            "wallet": "HOT",
+            "key_name": "TEST_KEY",
+        }
+        w3 = MagicMock()
+        typed_data = {"test": True}
+
+        with patch.dict(os.environ, {"TEST_KEY": "0xprivatekey"}):
+            result = sign(w3, signer, typed_data, b"", b"")
+
+        assert result == "0xsig"
+        mock_sign.assert_called_once_with("0xprivatekey", "0x1234", w3, typed_data)
+
+    @patch("src.eip712_typed_data.trezor_t.sign_typed_data")
+    @patch("builtins.input", return_value="")
+    def test_trezor_t_routing(self, _mock_input, mock_sign):
+        mock_sign.return_value = "0xsig_t"
+        signer = {"name": "Test", "address": "0xABC", "wallet": "T", "index": 2}
+        result = sign(MagicMock(), signer, {"data": True}, b"domain", b"msg")
+
+        assert result == "0xsig_t"
+        mock_sign.assert_called_once_with(2, "0xABC", {"data": True})
+
+    @patch("src.eip712_typed_data.trezor_1.sign_typed_data_hash")
+    @patch("builtins.input", return_value="")
+    def test_trezor_1_routing(self, _mock_input, mock_sign):
+        mock_sign.return_value = "0xsig_1"
+        signer = {"name": "Test", "address": "0xABC", "wallet": "1", "index": 3}
+        domain_hash = b"\x01" * 32
+        message_hash = b"\x02" * 32
+
+        result = sign(MagicMock(), signer, {}, domain_hash, message_hash)
+
+        assert result == "0xsig_1"
+        mock_sign.assert_called_once_with(3, "0xABC", domain_hash, message_hash)
+
+    @patch("src.eip712_typed_data.ledger_nano.sign_typed_data_hash")
+    @patch("builtins.input", return_value="")
+    def test_ledger_routing(self, _mock_input, mock_sign):
+        mock_sign.return_value = "0xsig_l"
+        signer = {"name": "Test", "address": "0xABC", "wallet": "L", "index": 1}
+        domain_hash = b"\x01" * 32
+        message_hash = b"\x02" * 32
+
+        result = sign(MagicMock(), signer, {}, domain_hash, message_hash)
+
+        assert result == "0xsig_l"
+        mock_sign.assert_called_once_with(1, "0xABC", domain_hash, message_hash)
+
+    @patch("builtins.input", return_value="")
+    def test_unknown_wallet_raises(self, _mock_input):
+        signer = {"name": "Test", "address": "0xABC", "wallet": "UNKNOWN", "index": 0}
+        with pytest.raises(Exception, match="Unknown wallet type"):
+            sign(MagicMock(), signer, {}, b"", b"")
+
+    def test_hot_wallet_missing_key_prints_error(self, capsys):
+        signer = {
+            "name": "Test",
+            "address": "0x1234",
+            "wallet": "HOT",
+            "key_name": "NONEXISTENT_KEY",
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            sign(MagicMock(), signer, {}, b"", b"")
+        captured = capsys.readouterr()
+        assert "not found" in captured.out
+        assert "Test" in captured.out
+
+    @patch("src.eip712_typed_data.hot_wallet.sign_typed_data")
+    def test_hot_wallet_returns_none_on_address_mismatch(self, mock_sign):
+        mock_sign.return_value = None
+        signer = {
+            "name": "Test",
+            "address": "0x1234",
+            "wallet": "HOT",
+            "key_name": "TEST_KEY",
+        }
+        with patch.dict(os.environ, {"TEST_KEY": "0xprivatekey"}):
+            result = sign(MagicMock(), signer, {}, b"", b"")
+        assert result is None
+
+    @patch("src.eip712_typed_data.trezor_t.sign_typed_data")
+    @patch("builtins.input", return_value="")
+    def test_trezor_t_returns_none_on_address_mismatch(self, _mock_input, mock_sign):
+        mock_sign.return_value = None
+        signer = {"name": "Test", "address": "0xABC", "wallet": "T", "index": 0}
+        result = sign(MagicMock(), signer, {}, b"", b"")
+        assert result is None
+
+    @patch("src.eip712_typed_data.trezor_1.sign_typed_data_hash")
+    @patch("builtins.input", return_value="")
+    def test_trezor_1_returns_none_on_address_mismatch(self, _mock_input, mock_sign):
+        mock_sign.return_value = None
+        signer = {"name": "Test", "address": "0xABC", "wallet": "1", "index": 0}
+        result = sign(MagicMock(), signer, {}, b"\x00" * 32, b"\x00" * 32)
+        assert result is None
+
+    @patch("src.eip712_typed_data.ledger_nano.sign_typed_data_hash")
+    @patch("builtins.input", return_value="")
+    def test_ledger_returns_none_on_address_mismatch(self, _mock_input, mock_sign):
+        mock_sign.return_value = None
+        signer = {"name": "Test", "address": "0xABC", "wallet": "L", "index": 0}
+        result = sign(MagicMock(), signer, {}, b"\x00" * 32, b"\x00" * 32)
+        assert result is None

--- a/transaction_signer/tests/test_hot_wallet.py
+++ b/transaction_signer/tests/test_hot_wallet.py
@@ -1,0 +1,108 @@
+import pytest
+from eth_account import Account
+from web3 import Web3
+
+from helpers import make_typed_data
+from src.wallets.hot_wallet import sign_transaction, sign_typed_data
+
+TEST_KEY = "0x4c0883a69102937d6231471b5dbb6204fe512961708279f3082e0e50e2872f62"
+TEST_ACCOUNT = Account.from_key(TEST_KEY)
+TEST_ADDRESS = TEST_ACCOUNT.address
+WRONG_ADDRESS = "0x0000000000000000000000000000000000000001"
+
+TYPED_DATA = make_typed_data()
+
+w3 = Web3()
+
+
+class TestSignTypedData:
+    def test_happy_path(self):
+        result = sign_typed_data(TEST_KEY, TEST_ADDRESS, w3, TYPED_DATA)
+        assert result is not None
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_returns_hex_string(self):
+        result = sign_typed_data(TEST_KEY, TEST_ADDRESS, w3, TYPED_DATA)
+        int(result, 16)
+
+    def test_deterministic(self):
+        sig1 = sign_typed_data(TEST_KEY, TEST_ADDRESS, w3, TYPED_DATA)
+        sig2 = sign_typed_data(TEST_KEY, TEST_ADDRESS, w3, TYPED_DATA)
+        assert sig1 == sig2
+
+    def test_address_mismatch_returns_none(self):
+        result = sign_typed_data(TEST_KEY, WRONG_ADDRESS, w3, TYPED_DATA)
+        assert result is None
+
+    def test_address_mismatch_prints_error(self, capsys):
+        sign_typed_data(TEST_KEY, WRONG_ADDRESS, w3, TYPED_DATA)
+        captured = capsys.readouterr()
+        assert "does not match" in captured.out
+        assert WRONG_ADDRESS in captured.out
+
+    def test_different_data_different_signature(self):
+        data2 = make_typed_data(nonce=999)
+        sig1 = sign_typed_data(TEST_KEY, TEST_ADDRESS, w3, TYPED_DATA)
+        sig2 = sign_typed_data(TEST_KEY, TEST_ADDRESS, w3, data2)
+        assert sig1 != sig2
+
+    def test_invalid_private_key_raises(self):
+        with pytest.raises(ValueError):
+            sign_typed_data("0xinvalid", TEST_ADDRESS, w3, TYPED_DATA)
+
+    def test_empty_private_key_raises(self):
+        with pytest.raises(ValueError):
+            sign_typed_data("", TEST_ADDRESS, w3, TYPED_DATA)
+
+    def test_missing_typed_data_field_raises(self):
+        bad_data = make_typed_data()
+        del bad_data["message"]["nonce"]
+        with pytest.raises(Exception):
+            sign_typed_data(TEST_KEY, TEST_ADDRESS, w3, bad_data)
+
+    def test_signature_is_65_bytes(self):
+        result = sign_typed_data(TEST_KEY, TEST_ADDRESS, w3, TYPED_DATA)
+        sig_bytes = bytes.fromhex(result.removeprefix("0x"))
+        assert len(sig_bytes) == 65
+
+
+UNSIGNED_TX = {
+    "to": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",
+    "value": 0,
+    "gas": 100000,
+    "gasPrice": 1000000000,
+    "nonce": 0,
+    "chainId": 8453,
+    "data": "0x",
+}
+
+
+class TestSignTransaction:
+    def test_happy_path(self):
+        result = sign_transaction(TEST_KEY, TEST_ADDRESS, w3, UNSIGNED_TX)
+        assert result is not None
+        assert hasattr(result, "rawTransaction") or hasattr(result, "raw_transaction")
+
+    def test_address_mismatch_returns_none(self):
+        result = sign_transaction(TEST_KEY, WRONG_ADDRESS, w3, UNSIGNED_TX)
+        assert result is None
+
+    def test_address_mismatch_prints_error(self, capsys):
+        sign_transaction(TEST_KEY, WRONG_ADDRESS, w3, UNSIGNED_TX)
+        captured = capsys.readouterr()
+        assert "does not match" in captured.out
+        assert WRONG_ADDRESS in captured.out
+
+    def test_invalid_private_key_raises(self):
+        with pytest.raises(ValueError):
+            sign_transaction("0xinvalid", TEST_ADDRESS, w3, UNSIGNED_TX)
+
+    def test_empty_private_key_raises(self):
+        with pytest.raises(ValueError):
+            sign_transaction("", TEST_ADDRESS, w3, UNSIGNED_TX)
+
+    def test_malformed_tx_raises(self):
+        incomplete_tx = {"to": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B"}
+        with pytest.raises(Exception):
+            sign_transaction(TEST_KEY, TEST_ADDRESS, w3, incomplete_tx)

--- a/transaction_signer/tests/test_ledger_nano.py
+++ b/transaction_signer/tests/test_ledger_nano.py
@@ -8,6 +8,7 @@ from helpers import HW_MESSAGE_HASH as MESSAGE_HASH
 from helpers import HW_SIGNER_ADDRESS as SIGNER_ADDRESS
 from helpers import HW_UNSIGNED_TX as UNSIGNED_TX
 from src.wallets.ledger_nano import (
+    _sign_transaction,
     _sign_typed_data_hash,
     get_address,
     get_path,
@@ -448,3 +449,65 @@ class TestSignTransaction:
         captured = capsys.readouterr()
         assert "Unexpected error" in captured.out
         mock_dongle.close.assert_called_once()
+
+
+class TestInternalSignTransaction:
+    def test_single_chunk_small_payload(self):
+        mock_dongle = MagicMock()
+        v_byte = bytes([1])
+        r_bytes = b"\xaa" * 32
+        s_bytes = b"\xbb" * 32
+        mock_dongle.exchange.return_value = v_byte + r_bytes + s_bytes
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+
+        v, r, s = _sign_transaction(mock_dongle, dongle_path, UNSIGNED_TX)
+
+        assert mock_dongle.exchange.call_count == 1
+        sent_apdu = mock_dongle.exchange.call_args[0][0]
+        assert sent_apdu[:2] == bytes.fromhex("e004")
+        assert sent_apdu[2] == 0x00
+        assert sent_apdu[3] == 0x02
+
+    def test_multi_chunk_large_payload(self):
+        mock_dongle = MagicMock()
+        v_byte = bytes([0])
+        r_bytes = b"\xcc" * 32
+        s_bytes = b"\xdd" * 32
+        mock_dongle.exchange.return_value = v_byte + r_bytes + s_bytes
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+
+        large_tx = {**UNSIGNED_TX, "data": "0x" + "ab" * 300}
+        _sign_transaction(mock_dongle, dongle_path, large_tx)
+
+        assert mock_dongle.exchange.call_count >= 2
+        calls = mock_dongle.exchange.call_args_list
+        assert calls[0][0][0][2] == 0x00
+        for call in calls[1:]:
+            assert call[0][0][2] == 0x80
+
+    def test_all_chunks_under_255_bytes(self):
+        mock_dongle = MagicMock()
+        mock_dongle.exchange.return_value = bytes([1]) + b"\x01" * 64
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+
+        large_tx = {**UNSIGNED_TX, "data": "0x" + "ab" * 300}
+        _sign_transaction(mock_dongle, dongle_path, large_tx)
+
+        for call in mock_dongle.exchange.call_args_list:
+            apdu = call[0][0]
+            payload_len = apdu[4]
+            assert payload_len <= 255
+
+    def test_returns_v_r_s(self):
+        mock_dongle = MagicMock()
+        v_byte = bytes([1])
+        r_bytes = b"\xaa" * 32
+        s_bytes = b"\xbb" * 32
+        mock_dongle.exchange.return_value = v_byte + r_bytes + s_bytes
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+
+        v, r, s = _sign_transaction(mock_dongle, dongle_path, UNSIGNED_TX)
+
+        assert v == 1
+        assert r == r_bytes
+        assert s == s_bytes

--- a/transaction_signer/tests/test_ledger_nano.py
+++ b/transaction_signer/tests/test_ledger_nano.py
@@ -1,0 +1,450 @@
+import struct
+from unittest.mock import MagicMock, patch
+
+from ledgerblue.commException import CommException
+
+from helpers import HW_DOMAIN_HASH as DOMAIN_HASH
+from helpers import HW_MESSAGE_HASH as MESSAGE_HASH
+from helpers import HW_SIGNER_ADDRESS as SIGNER_ADDRESS
+from helpers import HW_UNSIGNED_TX as UNSIGNED_TX
+from src.wallets.ledger_nano import (
+    _sign_typed_data_hash,
+    get_address,
+    get_path,
+    parse_bip32_path,
+    sign_transaction,
+    sign_typed_data_hash,
+)
+
+
+class TestGetPath:
+    def test_index_zero(self):
+        assert get_path(0) == "m/44'/60'/0'/0/0"
+
+    def test_index_five(self):
+        assert get_path(5) == "m/44'/60'/5'/0/0"
+
+    def test_index_in_third_position_hardened(self):
+        assert get_path(7) == "m/44'/60'/7'/0/0"
+
+
+class TestParseBip32Path:
+    def test_standard_path_bytes(self):
+        result = parse_bip32_path("m/44'/60'/0'/0/0")
+        expected = (
+            struct.pack(">I", 0x80000000 | 44)
+            + struct.pack(">I", 0x80000000 | 60)
+            + struct.pack(">I", 0x80000000 | 0)
+            + struct.pack(">I", 0)
+            + struct.pack(">I", 0)
+        )
+        assert result == expected
+
+    def test_hardened_elements_have_high_bit(self):
+        result = parse_bip32_path("m/44'/60'/0'/0/0")
+        first_element = struct.unpack(">I", result[0:4])[0]
+        assert first_element == 0x80000000 | 44
+
+    def test_non_hardened_elements_are_plain(self):
+        result = parse_bip32_path("m/44'/60'/0'/0/0")
+        fourth_element = struct.unpack(">I", result[12:16])[0]
+        assert fourth_element == 0
+
+    def test_result_length_five_elements(self):
+        result = parse_bip32_path("m/44'/60'/0'/0/0")
+        assert len(result) == 20
+
+    def test_big_endian_packing(self):
+        result = parse_bip32_path("m/44'/60'/0'/0/0")
+        assert result[0:4] == b"\x80\x00\x00\x2c"
+
+
+class TestGetAddress:
+    def test_parses_address_from_apdu_response(self):
+        address_str = b"1234567890abcdef1234567890abcdef12345678"
+        pubkey_len = 65
+        # response: pubkey_len byte, pubkey bytes, address_len byte, address ASCII
+        mock_response = (
+            bytes([pubkey_len])
+            + b"\x00" * pubkey_len
+            + bytes([len(address_str)])
+            + address_str
+        )
+        mock_dongle = MagicMock()
+        mock_dongle.exchange.return_value = mock_response
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+
+        result = get_address(mock_dongle, dongle_path)
+
+        assert result == "0x1234567890abcdef1234567890abcdef12345678"
+
+    def test_sends_correct_apdu_prefix(self):
+        address_str = b"abcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        mock_response = bytes([65]) + b"\x00" * 65 + bytes([40]) + address_str
+        mock_dongle = MagicMock()
+        mock_dongle.exchange.return_value = mock_response
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+
+        get_address(mock_dongle, dongle_path)
+
+        sent_apdu = mock_dongle.exchange.call_args[0][0]
+        assert sent_apdu[:4] == bytes.fromhex("e0020100")
+
+
+class TestInternalSignTypedDataHash:
+    def test_sends_correct_apdu_command(self):
+        mock_dongle = MagicMock()
+        v = b"\x1b"
+        r = b"\x01" * 32
+        s = b"\x02" * 32
+        mock_dongle.exchange.return_value = v + r + s
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+
+        _sign_typed_data_hash(mock_dongle, dongle_path, DOMAIN_HASH, MESSAGE_HASH)
+
+        sent_apdu = mock_dongle.exchange.call_args[0][0]
+        assert sent_apdu[:4] == bytes.fromhex("e00c0000")
+
+    def test_payload_contains_path_and_hashes(self):
+        mock_dongle = MagicMock()
+        mock_dongle.exchange.return_value = b"\x1b" + b"\x01" * 32 + b"\x02" * 32
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+
+        _sign_typed_data_hash(mock_dongle, dongle_path, DOMAIN_HASH, MESSAGE_HASH)
+
+        sent_apdu = mock_dongle.exchange.call_args[0][0]
+        # Payload starts after command (4) + length (1) + path count (1)
+        payload_start = 6
+        payload = sent_apdu[payload_start:]
+        assert dongle_path in payload
+        assert DOMAIN_HASH in payload
+        assert MESSAGE_HASH in payload
+
+    def test_returns_r_s_v_concatenated(self):
+        mock_dongle = MagicMock()
+        v = b"\x1b"
+        r = b"\xaa" * 32
+        s = b"\xbb" * 32
+        mock_dongle.exchange.return_value = v + r + s
+
+        dongle_path = parse_bip32_path("m/44'/60'/0'/0/0")
+        result = _sign_typed_data_hash(
+            mock_dongle, dongle_path, DOMAIN_HASH, MESSAGE_HASH
+        )
+
+        # Source reorders to r + s + v
+        assert result == r + s + v
+        assert len(result) == 65
+
+
+class TestSignTypedDataHash:
+    @patch("src.wallets.ledger_nano._sign_typed_data_hash")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_returns_hex_signature(self, mock_get_dongle, mock_get_addr, mock_sign):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign.return_value = b"\xab" * 65
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result == (b"\xab" * 65).hex()
+
+    @patch("src.wallets.ledger_nano._sign_typed_data_hash")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_prints_hashes_before_signing(
+        self, mock_get_dongle, mock_get_addr, mock_sign, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign.return_value = b"\xab" * 65
+
+        sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        captured = capsys.readouterr()
+        assert DOMAIN_HASH.hex() in captured.out
+        assert MESSAGE_HASH.hex() in captured.out
+
+    @patch("src.wallets.ledger_nano._sign_typed_data_hash")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_closes_dongle_on_success(self, mock_get_dongle, mock_get_addr, mock_sign):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign.return_value = b"\xab" * 65
+
+        sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano._sign_typed_data_hash")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_signature_is_r_s_v(self, mock_get_dongle, mock_get_addr, mock_sign):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        sig_bytes = b"\x01" * 32 + b"\x02" * 32 + b"\x1b"
+        mock_sign.return_value = sig_bytes
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result == sig_bytes.hex()
+        assert len(bytes.fromhex(result)) == 65
+
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_comm_exception_on_get_dongle_returns_none(self, mock_get_dongle, capsys):
+        mock_get_dongle.side_effect = CommException("connection failed", 0x6985)
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Ledger device" in captured.out
+
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_address_mismatch_returns_none(
+        self, mock_get_dongle, mock_get_addr, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = "0xwrongaddress"
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "does not match" in captured.out
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_comm_exception_during_get_address(
+        self, mock_get_dongle, mock_get_addr, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.side_effect = CommException("comm fail", 0x6985)
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Ledger device" in captured.out
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_generic_exception_during_get_address(
+        self, mock_get_dongle, mock_get_addr, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.side_effect = Exception("unexpected failure")
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Unexpected error" in captured.out
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano._sign_typed_data_hash")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_comm_exception_during_signing(
+        self, mock_get_dongle, mock_get_addr, mock_sign, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign.side_effect = CommException("signing comm fail", 0x6985)
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Ledger device" in captured.out
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano._sign_typed_data_hash")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_generic_exception_during_signing(
+        self, mock_get_dongle, mock_get_addr, mock_sign, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign.side_effect = Exception("signing blew up")
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Unexpected error" in captured.out
+        mock_dongle.close.assert_called_once()
+
+
+class TestSignTransaction:
+    @patch("src.wallets.ledger_nano._sign_transaction")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_returns_attribute_dict(self, mock_get_dongle, mock_get_addr, mock_sign_tx):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign_tx.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is not None
+        assert hasattr(result, "raw_transaction")
+        assert hasattr(result, "hash")
+        assert hasattr(result, "r")
+        assert hasattr(result, "s")
+        assert hasattr(result, "v")
+
+    @patch("src.wallets.ledger_nano._sign_transaction")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_raw_transaction_eip1559_prefix(
+        self, mock_get_dongle, mock_get_addr, mock_sign_tx
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign_tx.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result.raw_transaction.hex().startswith("0x02")
+
+    @patch("src.wallets.ledger_nano._sign_transaction")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_r_s_are_ints_v_is_original(
+        self, mock_get_dongle, mock_get_addr, mock_sign_tx
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign_tx.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert isinstance(result.r, int)
+        assert isinstance(result.s, int)
+        assert result.r == int.from_bytes(b"\x01" * 32, "big")
+        assert result.s == int.from_bytes(b"\x02" * 32, "big")
+        assert result.v == 1
+
+    @patch("src.wallets.ledger_nano._sign_transaction")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_closes_dongle_on_success(
+        self, mock_get_dongle, mock_get_addr, mock_sign_tx
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign_tx.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_comm_exception_on_get_dongle_returns_none(self, mock_get_dongle, capsys):
+        mock_get_dongle.side_effect = CommException("connection failed", 0x6985)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Ledger device" in captured.out
+
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_address_mismatch_returns_none(
+        self, mock_get_dongle, mock_get_addr, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = "0xwrongaddress"
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "does not match" in captured.out
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_comm_exception_during_get_address(
+        self, mock_get_dongle, mock_get_addr, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.side_effect = CommException("comm fail", 0x6985)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_generic_exception_during_get_address(
+        self, mock_get_dongle, mock_get_addr, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.side_effect = Exception("unexpected failure")
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano._sign_transaction")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_comm_exception_during_signing(
+        self, mock_get_dongle, mock_get_addr, mock_sign_tx, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign_tx.side_effect = CommException("signing comm fail", 0x6985)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Ledger device" in captured.out
+        mock_dongle.close.assert_called_once()
+
+    @patch("src.wallets.ledger_nano._sign_transaction")
+    @patch("src.wallets.ledger_nano.get_address")
+    @patch("src.wallets.ledger_nano.getDongle")
+    def test_generic_exception_during_signing(
+        self, mock_get_dongle, mock_get_addr, mock_sign_tx, capsys
+    ):
+        mock_dongle = MagicMock()
+        mock_get_dongle.return_value = mock_dongle
+        mock_get_addr.return_value = SIGNER_ADDRESS
+        mock_sign_tx.side_effect = Exception("signing blew up")
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Unexpected error" in captured.out
+        mock_dongle.close.assert_called_once()

--- a/transaction_signer/tests/test_safe_transaction.py
+++ b/transaction_signer/tests/test_safe_transaction.py
@@ -1,0 +1,353 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helpers import MULTISEND_ADDRESS, RELAY_TX_CONSTANTS, make_mock_safe
+from src.safe_transaction import create, sign
+
+TO = MULTISEND_ADDRESS
+RAW_DATA = "0xabcdef"
+SIGNATURES = "0xaabbccdd"
+RELAYER_ADDR = "0x3333333333333333333333333333333333333333"
+
+
+def make_mock_w3(nonce=0, gas_estimate=200000, gas_price=1000000000):
+    w3 = MagicMock()
+    w3.eth.get_transaction_count.return_value = nonce
+    w3.eth.estimate_gas.return_value = gas_estimate
+    w3.eth.gas_price = gas_price
+    return w3
+
+
+class TestCreateGasBranching:
+    def test_gas_zero_estimates_dynamically(self):
+        w3 = make_mock_w3(gas_estimate=300000)
+        safe = make_mock_safe()
+
+        result = create(
+            w3,
+            safe,
+            TO,
+            RELAY_TX_CONSTANTS,
+            RAW_DATA,
+            0,
+            SIGNATURES,
+            RELAYER_ADDR,
+            gas=0,
+            max_fee_per_gas=100,
+            max_priority_fee_per_gas=10,
+        )
+
+        w3.eth.estimate_gas.assert_called_once()
+        assert result["gas"] == 300000
+
+    def test_gas_nonzero_uses_provided(self):
+        w3 = make_mock_w3()
+        safe = make_mock_safe()
+
+        result = create(
+            w3,
+            safe,
+            TO,
+            RELAY_TX_CONSTANTS,
+            RAW_DATA,
+            0,
+            SIGNATURES,
+            RELAYER_ADDR,
+            gas=500000,
+            max_fee_per_gas=100,
+            max_priority_fee_per_gas=10,
+        )
+
+        w3.eth.estimate_gas.assert_not_called()
+        assert result["gas"] == 500000
+
+    def test_gas_estimate_failure_propagates(self):
+        w3 = make_mock_w3()
+        w3.eth.estimate_gas.side_effect = Exception("estimation failed")
+        safe = make_mock_safe()
+
+        with pytest.raises(Exception, match="estimation failed"):
+            create(
+                w3,
+                safe,
+                TO,
+                RELAY_TX_CONSTANTS,
+                RAW_DATA,
+                0,
+                SIGNATURES,
+                RELAYER_ADDR,
+                gas=0,
+                max_fee_per_gas=100,
+                max_priority_fee_per_gas=10,
+            )
+
+
+class TestCreateNonceAndChainId:
+    def test_fetches_nonce_from_relayer_address(self):
+        w3 = make_mock_w3(nonce=42)
+        safe = make_mock_safe()
+
+        create(
+            w3,
+            safe,
+            TO,
+            RELAY_TX_CONSTANTS,
+            RAW_DATA,
+            0,
+            SIGNATURES,
+            RELAYER_ADDR,
+            gas=100000,
+            max_fee_per_gas=100,
+            max_priority_fee_per_gas=10,
+        )
+
+        w3.eth.get_transaction_count.assert_called_once_with(RELAYER_ADDR)
+
+    def test_fetches_chain_id_from_safe(self):
+        w3 = make_mock_w3()
+        safe = make_mock_safe(chain_id=10)
+
+        create(
+            w3,
+            safe,
+            TO,
+            RELAY_TX_CONSTANTS,
+            RAW_DATA,
+            0,
+            SIGNATURES,
+            RELAYER_ADDR,
+            gas=100000,
+            max_fee_per_gas=100,
+            max_priority_fee_per_gas=10,
+        )
+
+        safe.functions.getChainId.assert_called_once()
+
+
+class TestCreateMaxFeeBranching:
+    def test_max_fee_zero_calculates_from_gas_price(self):
+        w3 = make_mock_w3(gas_price=2000000000)
+        safe = make_mock_safe()
+        priority_fee = 1000000
+
+        result = create(
+            w3,
+            safe,
+            TO,
+            RELAY_TX_CONSTANTS,
+            RAW_DATA,
+            0,
+            SIGNATURES,
+            RELAYER_ADDR,
+            gas=100000,
+            max_fee_per_gas=0,
+            max_priority_fee_per_gas=priority_fee,
+        )
+
+        assert result["maxFeePerGas"] == 2000000000 + priority_fee
+
+    def test_max_fee_nonzero_uses_provided(self):
+        w3 = make_mock_w3()
+        safe = make_mock_safe()
+
+        result = create(
+            w3,
+            safe,
+            TO,
+            RELAY_TX_CONSTANTS,
+            RAW_DATA,
+            0,
+            SIGNATURES,
+            RELAYER_ADDR,
+            gas=100000,
+            max_fee_per_gas=5000000000,
+            max_priority_fee_per_gas=10,
+        )
+
+        assert result["maxFeePerGas"] == 5000000000
+
+    def test_priority_fee_always_set(self):
+        w3 = make_mock_w3()
+        safe = make_mock_safe()
+
+        result = create(
+            w3,
+            safe,
+            TO,
+            RELAY_TX_CONSTANTS,
+            RAW_DATA,
+            0,
+            SIGNATURES,
+            RELAYER_ADDR,
+            gas=100000,
+            max_fee_per_gas=100,
+            max_priority_fee_per_gas=42,
+        )
+
+        assert result["maxPriorityFeePerGas"] == 42
+
+
+class TestSignRouting:
+    @patch("src.safe_transaction.hot_wallet.sign_transaction")
+    def test_hot_wallet_happy_path(self, mock_sign):
+        mock_sign.return_value = {"raw_transaction": "0x"}
+        relayer = {
+            "name": "R",
+            "address": "0xR",
+            "wallet": "HOT",
+            "key_name": "TEST_KEY",
+        }
+        w3 = MagicMock()
+
+        with patch.dict(os.environ, {"TEST_KEY": "0xprivatekey"}):
+            result = sign(w3, {"tx": True}, relayer)
+
+        assert result == {"raw_transaction": "0x"}
+        mock_sign.assert_called_once_with("0xprivatekey", "0xR", w3, {"tx": True})
+
+    def test_hot_wallet_missing_key_returns_false(self):
+        relayer = {
+            "name": "R",
+            "address": "0xR",
+            "wallet": "HOT",
+            "key_name": "MISSING_KEY",
+        }
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = sign(MagicMock(), {}, relayer)
+
+        assert result is False
+
+    @patch("src.safe_transaction.trezor_t.sign_transaction")
+    @patch("builtins.input", return_value="")
+    def test_trezor_t_routing(self, _mock_input, mock_sign):
+        mock_sign.return_value = "signed"
+        relayer = {"name": "R", "address": "0xR", "wallet": "T", "index": 5}
+        unsigned_tx = {"data": "0x"}
+
+        result = sign(MagicMock(), unsigned_tx, relayer)
+
+        assert result == "signed"
+        mock_sign.assert_called_once_with(5, "0xR", unsigned_tx)
+
+    @patch("src.safe_transaction.trezor_1.sign_transaction")
+    @patch("builtins.input", return_value="")
+    def test_trezor_1_routing(self, _mock_input, mock_sign):
+        mock_sign.return_value = "signed"
+        relayer = {"name": "R", "address": "0xR", "wallet": "1", "index": 3}
+        unsigned_tx = {"data": "0x"}
+
+        result = sign(MagicMock(), unsigned_tx, relayer)
+
+        assert result == "signed"
+        mock_sign.assert_called_once_with(3, "0xR", unsigned_tx)
+
+    @patch("builtins.input", return_value="")
+    def test_unknown_wallet_raises(self, _mock_input):
+        relayer = {"name": "R", "address": "0xR", "wallet": "X", "index": 0}
+
+        with pytest.raises(Exception, match="Unknown or unsupported wallet type"):
+            sign(MagicMock(), {}, relayer)
+
+    def test_hot_wallet_missing_key_prints_error(self, capsys):
+        relayer = {
+            "name": "R",
+            "address": "0xR",
+            "wallet": "HOT",
+            "key_name": "MISSING_KEY",
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            sign(MagicMock(), {}, relayer)
+        captured = capsys.readouterr()
+        assert "not found" in captured.out
+
+    @patch("src.safe_transaction.hot_wallet.sign_transaction")
+    def test_hot_wallet_returns_none_on_address_mismatch(self, mock_sign):
+        mock_sign.return_value = None
+        relayer = {
+            "name": "R",
+            "address": "0xR",
+            "wallet": "HOT",
+            "key_name": "TEST_KEY",
+        }
+        with patch.dict(os.environ, {"TEST_KEY": "0xprivatekey"}):
+            result = sign(MagicMock(), {}, relayer)
+        assert result is None
+
+    @patch("src.safe_transaction.trezor_t.sign_transaction")
+    @patch("builtins.input", return_value="")
+    def test_trezor_t_returns_none_on_address_mismatch(self, _mock_input, mock_sign):
+        mock_sign.return_value = None
+        relayer = {"name": "R", "address": "0xR", "wallet": "T", "index": 0}
+        result = sign(MagicMock(), {}, relayer)
+        assert result is None
+
+    @patch("src.safe_transaction.trezor_1.sign_transaction")
+    @patch("builtins.input", return_value="")
+    def test_trezor_1_returns_none_on_address_mismatch(self, _mock_input, mock_sign):
+        mock_sign.return_value = None
+        relayer = {"name": "R", "address": "0xR", "wallet": "1", "index": 0}
+        result = sign(MagicMock(), {}, relayer)
+        assert result is None
+
+    @patch("src.safe_transaction.ledger_nano.sign_transaction")
+    @patch("builtins.input", return_value="")
+    def test_ledger_wallet_routes_to_ledger(self, _mock_input, mock_sign):
+        mock_sign.return_value = MagicMock()
+        relayer = {"name": "R", "address": "0xR", "wallet": "L", "index": 2}
+        sign(MagicMock(), {}, relayer)
+        mock_sign.assert_called_once_with(2, "0xR", {})
+
+    @patch("src.safe_transaction.ledger_nano.sign_transaction")
+    @patch("builtins.input", return_value="")
+    def test_ledger_address_mismatch_returns_none(self, _mock_input, mock_sign):
+        mock_sign.return_value = None
+        relayer = {"name": "R", "address": "0xR", "wallet": "L", "index": 0}
+        result = sign(MagicMock(), {}, relayer)
+        assert result is None
+
+
+class TestCreateMissingConstants:
+    def test_missing_constant_key_raises(self):
+        w3 = make_mock_w3()
+        safe = make_mock_safe()
+        incomplete = {
+            k: v for k, v in RELAY_TX_CONSTANTS.items() if k != "VALUE_RELAY_TX"
+        }
+        with pytest.raises(KeyError):
+            create(
+                w3,
+                safe,
+                TO,
+                incomplete,
+                RAW_DATA,
+                0,
+                SIGNATURES,
+                RELAYER_ADDR,
+                gas=100000,
+                max_fee_per_gas=100,
+                max_priority_fee_per_gas=10,
+            )
+
+    def test_build_transaction_failure_propagates(self):
+        w3 = make_mock_w3()
+        safe = make_mock_safe()
+        safe.functions.execTransaction.return_value.build_transaction.side_effect = (
+            Exception("build failed")
+        )
+        with pytest.raises(Exception, match="build failed"):
+            create(
+                w3,
+                safe,
+                TO,
+                RELAY_TX_CONSTANTS,
+                RAW_DATA,
+                0,
+                SIGNATURES,
+                RELAYER_ADDR,
+                gas=100000,
+                max_fee_per_gas=100,
+                max_priority_fee_per_gas=10,
+            )

--- a/transaction_signer/tests/test_safe_transaction.py
+++ b/transaction_signer/tests/test_safe_transaction.py
@@ -40,7 +40,7 @@ class TestCreateGasBranching:
         )
 
         w3.eth.estimate_gas.assert_called_once()
-        assert result["gas"] == 300000
+        assert result["gas"] == int(300000 * 1.2)
 
     def test_gas_nonzero_uses_provided(self):
         w3 = make_mock_w3()

--- a/transaction_signer/tests/test_signature_loading.py
+++ b/transaction_signer/tests/test_signature_loading.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+
+from src.utils.signatures import load
+
+
+class TestSignatureLoadingHappyPath:
+    def test_valid_file(self, tmp_path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        sigs = {"0xabc123": {"0xSigner": "0xSignature"}}
+        (out_dir / "signatures.txt").write_text(json.dumps(sigs))
+        assert load(str(tmp_path)) == sigs
+
+    def test_nested_signatures(self, tmp_path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        sigs = {
+            "hash_a": {"0xAddr1": "sig1", "0xAddr2": "sig2"},
+            "hash_b": {"0xAddr3": "sig3"},
+        }
+        (out_dir / "signatures.txt").write_text(json.dumps(sigs))
+        assert load(str(tmp_path)) == sigs
+
+
+class TestSignatureLoadingFallback:
+    def test_empty_file(self, tmp_path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        (out_dir / "signatures.txt").write_text("")
+        assert load(str(tmp_path)) == {}
+
+    def test_missing_file(self, tmp_path):
+        assert load(str(tmp_path)) == {}
+
+    def test_malformed_json(self, tmp_path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        (out_dir / "signatures.txt").write_text("{bad json")
+        assert load(str(tmp_path)) == {}
+
+    def test_missing_out_directory(self, tmp_path):
+        assert load(str(tmp_path)) == {}
+
+    def test_json_array_instead_of_dict_raises(self, tmp_path):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        (out_dir / "signatures.txt").write_text("[1, 2, 3]")
+        with pytest.raises(TypeError, match="Expected dict"):
+            load(str(tmp_path))

--- a/transaction_signer/tests/test_signature_sorting.py
+++ b/transaction_signer/tests/test_signature_sorting.py
@@ -46,7 +46,12 @@ class TestSortBySignerHandlesMixedCase:
     def test_case_insensitive_sort(self):
         addr_lower = "0xabcdef0000000000000000000000000000000000"
         addr_upper = "0xABCDEF0000000000000000000000000000000000"
-        assert int(addr_lower, 16) == int(addr_upper, 16)
+        sigs = {addr_lower: "sig_lower", addr_upper: "sig_upper"}
+        result = sort_by_signer(sigs)
+        assert len(result) == 2
+        assert result[0][0] == result[1][0] or int(result[0][0], 16) <= int(
+            result[1][0], 16
+        )
 
     def test_three_signers_with_problematic_ordering(self):
         sigs = {

--- a/transaction_signer/tests/test_signature_sorting.py
+++ b/transaction_signer/tests/test_signature_sorting.py
@@ -1,0 +1,98 @@
+from src.utils.signatures import concatenate, sort_by_signer
+
+SAMPLE_SIGNERS = {
+    "0x3A1b2C3d4E5f6A7B8c9D0E1F2a3B4c5D6e7F8a9B": "sig_1",
+    "0x7e8F9a0B1c2D3e4F5A6b7C8d9E0f1A2B3c4D5e6F": "sig_2",
+    "0xBb1C2d3E4f5A6b7C8D9e0F1a2B3c4D5E6f7A8b9C": "sig_3",
+    "0xCa2D3e4F5a6B7c8D9E0f1A2b3C4d5E6F7a8B9c0D": "sig_4",
+    "0xDb3E4f5A6b7C8d9E0F1a2B3c4D5e6F7A8b9C0d1E": "sig_5",
+    "0xFc4F5a6B7c8D9e0F1A2b3C4d5E6f7A8B9c0D1e2F": "sig_6",
+}
+
+
+class TestSortBySignerProducesAscendingOrder:
+    def test_sample_signers_ascending(self):
+        result = sort_by_signer(SAMPLE_SIGNERS)
+        values = [int(addr, 16) for addr, _ in result]
+        assert values == sorted(values)
+
+    def test_all_pairs_numerically_ordered(self):
+        result = sort_by_signer(SAMPLE_SIGNERS)
+        addrs = [int(addr, 16) for addr, _ in result]
+        for i in range(len(addrs) - 1):
+            assert addrs[i] < addrs[i + 1]
+
+
+class TestSortBySignerHandlesMixedCase:
+    def test_lowercase_start_sorted_correctly(self):
+        sigs = {
+            "0xaB5801a7D398351b8bE11C439e05C5B3259aeC9B": "sig_low",
+            "0xF192e3A4b5C6d7E8f9A0B1c2D3e4F5a6B7c8D9e0": "sig_high",
+        }
+        result = sort_by_signer(sigs)
+        addrs = [int(addr, 16) for addr, _ in result]
+        assert addrs == sorted(addrs)
+        assert result[0][0].startswith("0xaB")
+
+    def test_uppercase_F_vs_lowercase_a(self):
+        sigs = {
+            "0xF000000000000000000000000000000000000000": "sig_f",
+            "0xa000000000000000000000000000000000000000": "sig_a",
+        }
+        result = sort_by_signer(sigs)
+        assert result[0][0].startswith("0xa")
+        assert result[1][0].startswith("0xF")
+
+    def test_case_insensitive_sort(self):
+        addr_lower = "0xabcdef0000000000000000000000000000000000"
+        addr_upper = "0xABCDEF0000000000000000000000000000000000"
+        assert int(addr_lower, 16) == int(addr_upper, 16)
+
+    def test_three_signers_with_problematic_ordering(self):
+        sigs = {
+            "0xaB5801a7D398351b8bE11C439e05C5B3259aeC9B": "sig_1",
+            "0xB12345678901234567890123456789012345abcd": "sig_2",
+            "0xF192e3A4b5C6d7E8f9A0B1c2D3e4F5a6B7c8D9e0": "sig_3",
+        }
+        result = sort_by_signer(sigs)
+        addrs = [int(addr, 16) for addr, _ in result]
+        assert addrs == sorted(addrs)
+
+
+class TestSortBySignerPreservesPairing:
+    def test_signatures_stay_paired_with_addresses(self):
+        addr_high = "0xF192e3A4b5C6d7E8f9A0B1c2D3e4F5a6B7c8D9e0"
+        addr_low = "0x3A1b2C3d4E5f6A7B8c9D0E1F2a3B4c5D6e7F8a9B"
+        sigs = {
+            addr_high: "aabbcc",
+            addr_low: "ddeeff",
+        }
+        result = sort_by_signer(sigs)
+        assert result[0] == (addr_low, "ddeeff")
+        assert result[1] == (addr_high, "aabbcc")
+
+    def test_empty_dict(self):
+        assert sort_by_signer({}) == []
+
+    def test_single_signer(self):
+        sigs = {"0xABCD000000000000000000000000000000000000": "only_sig"}
+        result = sort_by_signer(sigs)
+        assert len(result) == 1
+        assert result[0][1] == "only_sig"
+
+
+class TestConcatenate:
+    def test_concatenates_in_order(self):
+        items = [
+            ("0xaaa", "1111"),
+            ("0xbbb", "2222"),
+            ("0xccc", "3333"),
+        ]
+        assert concatenate(items) == "0x111122223333"
+
+    def test_empty_list(self):
+        assert concatenate([]) == "0x"
+
+    def test_single_signature(self):
+        items = [("0xaaa", "abcdef")]
+        assert concatenate(items) == "0xabcdef"

--- a/transaction_signer/tests/test_tenderly.py
+++ b/transaction_signer/tests/test_tenderly.py
@@ -157,7 +157,14 @@ class TestTenderlyHappyPath:
         state_objects = sim_call_body["state_objects"]
         assert safe.address in state_objects
         storage = state_objects[safe.address]["storage"]
-        assert len(storage) == 1
+        threshold_slot = (
+            "0x0000000000000000000000000000000000000000000000000000000000000004"
+        )
+        assert threshold_slot in storage
+        assert (
+            storage[threshold_slot]
+            == "0x0000000000000000000000000000000000000000000000000000000000000001"
+        )
 
 
 class TestTenderlyEmptyOwners:

--- a/transaction_signer/tests/test_tenderly.py
+++ b/transaction_signer/tests/test_tenderly.py
@@ -1,0 +1,195 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helpers import MULTISEND_ADDRESS, SAFE_TX_CONSTANTS, make_mock_safe
+from src.tenderly import simulate
+
+TO = MULTISEND_ADDRESS
+RAW_DATA = "0x1234"
+TENDERLY_URL = "https://api.tenderly.co/api/v1/account/test/project/test"
+
+
+class TestTenderlyMissingKey:
+    def test_raises_when_tenderly_key_not_set(self):
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(
+                Exception, match="TENDERLY_KEY environment variable is not set"
+            ):
+                simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+
+class TestTenderlyHttpError:
+    @patch("src.tenderly.requests.post")
+    def test_raises_on_non_200(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        mock_post.return_value = mock_response
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            with pytest.raises(Exception, match="Tenderly simulation failed.*401"):
+                simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+    @patch("src.tenderly.requests.post")
+    def test_raises_on_500(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_post.return_value = mock_response
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            with pytest.raises(Exception, match="Tenderly simulation failed.*500"):
+                simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+
+class TestTenderlyMalformedResponse:
+    @patch("src.tenderly.requests.post")
+    def test_raises_when_no_simulation_key(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"error": "something went wrong"}
+        mock_post.return_value = mock_response
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            with pytest.raises(Exception, match="Unexpected Tenderly response"):
+                simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+    @patch("src.tenderly.requests.post")
+    def test_raises_when_no_id_in_simulation(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"simulation": {"status": "failed"}}
+        mock_post.return_value = mock_response
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            with pytest.raises(Exception, match="Unexpected Tenderly response"):
+                simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+
+class TestTenderlyHappyPath:
+    @patch("src.tenderly.requests.post")
+    def test_prints_simulation_url(self, mock_post, capsys):
+        sim_response = MagicMock()
+        sim_response.status_code = 200
+        sim_response.json.return_value = {"simulation": {"id": "sim_abc123"}}
+
+        share_response = MagicMock()
+        share_response.status_code = 200
+
+        mock_post.side_effect = [sim_response, share_response]
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+        captured = capsys.readouterr()
+        assert "sim_abc123" in captured.out
+        assert "tdly.co/shared/simulation" in captured.out
+
+    @patch("src.tenderly.requests.post")
+    def test_calls_simulate_then_share(self, mock_post):
+        sim_response = MagicMock()
+        sim_response.status_code = 200
+        sim_response.json.return_value = {"simulation": {"id": "sim_xyz"}}
+
+        share_response = MagicMock()
+        mock_post.side_effect = [sim_response, share_response]
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+        assert mock_post.call_count == 2
+        assert "simulate" in str(mock_post.call_args_list[0])
+        assert "share" in str(mock_post.call_args_list[1])
+
+    @patch("src.tenderly.requests.post")
+    def test_sends_correct_headers(self, mock_post):
+        sim_response = MagicMock()
+        sim_response.status_code = 200
+        sim_response.json.return_value = {"simulation": {"id": "sim_1"}}
+        share_response = MagicMock()
+        mock_post.side_effect = [sim_response, share_response]
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "my_secret_key"}):
+            simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+        for call in mock_post.call_args_list:
+            headers = call.kwargs.get("headers", {})
+            assert headers.get("X-Access-Key") == "my_secret_key"
+
+    @patch("src.tenderly.requests.post")
+    def test_uses_first_owner_as_sender(self, mock_post):
+        sim_response = MagicMock()
+        sim_response.status_code = 200
+        sim_response.json.return_value = {"simulation": {"id": "sim_1"}}
+        share_response = MagicMock()
+        mock_post.side_effect = [sim_response, share_response]
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+        sim_call_body = mock_post.call_args_list[0].kwargs["json"]
+        assert sim_call_body["from"] == "0x2222222222222222222222222222222222222222"
+
+    @patch("src.tenderly.requests.post")
+    def test_overrides_threshold_to_one(self, mock_post):
+        sim_response = MagicMock()
+        sim_response.status_code = 200
+        sim_response.json.return_value = {"simulation": {"id": "sim_1"}}
+        share_response = MagicMock()
+        mock_post.side_effect = [sim_response, share_response]
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+        sim_call_body = mock_post.call_args_list[0].kwargs["json"]
+        state_objects = sim_call_body["state_objects"]
+        assert safe.address in state_objects
+        storage = state_objects[safe.address]["storage"]
+        assert len(storage) == 1
+
+
+class TestTenderlyEmptyOwners:
+    def test_raises_on_no_owners(self):
+        safe = make_mock_safe(owners=[])
+        safe.functions.getOwners.return_value.call.return_value = []
+
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            with pytest.raises(IndexError):
+                simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+
+class TestTenderlyNetworkError:
+    @patch("src.tenderly.requests.post")
+    def test_connection_error_propagates(self, mock_post):
+        import requests
+
+        mock_post.side_effect = requests.ConnectionError("connection refused")
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            with pytest.raises(requests.ConnectionError):
+                simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)
+
+    @patch("src.tenderly.requests.post")
+    def test_non_json_response_body_raises(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = ValueError("No JSON")
+        mock_post.return_value = mock_response
+
+        safe = make_mock_safe()
+        with patch.dict(os.environ, {"TENDERLY_KEY": "test_key"}):
+            with pytest.raises(ValueError):
+                simulate(safe, TO, RAW_DATA, 1, SAFE_TX_CONSTANTS, TENDERLY_URL)

--- a/transaction_signer/tests/test_trezor_1.py
+++ b/transaction_signer/tests/test_trezor_1.py
@@ -1,0 +1,287 @@
+from unittest.mock import MagicMock, patch
+
+from trezorlib.transport import TransportException
+
+from helpers import HW_DOMAIN_HASH as DOMAIN_HASH
+from helpers import HW_MESSAGE_HASH as MESSAGE_HASH
+from helpers import HW_SIGNER_ADDRESS as SIGNER_ADDRESS
+from helpers import HW_UNSIGNED_TX as UNSIGNED_TX
+from src.wallets.trezor_1 import get_path, sign_transaction, sign_typed_data_hash
+
+
+class TestGetPath:
+    def test_index_zero(self):
+        assert get_path(0) == "m/44'/60'/0'/0/0"
+
+    def test_index_five(self):
+        assert get_path(5) == "m/44'/60'/0'/0/5"
+
+    def test_large_index(self):
+        assert get_path(999999) == "m/44'/60'/0'/0/999999"
+
+
+class TestSignTypedDataHash:
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_returns_hex_signature(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_sig = MagicMock()
+        mock_sig.signature = b"\xab" * 65
+        mock_eth.sign_typed_data_hash.return_value = mock_sig
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result == (b"\xab" * 65).hex()
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_calls_close_on_success(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_sig = MagicMock()
+        mock_sig.signature = b"\xab" * 65
+        mock_eth.sign_typed_data_hash.return_value = mock_sig
+
+        sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        mock_client.close.assert_called_once()
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_passes_correct_args_to_sign(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_sig = MagicMock()
+        mock_sig.signature = b"\xab" * 65
+        mock_eth.sign_typed_data_hash.return_value = mock_sig
+
+        sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        call_kwargs = mock_eth.sign_typed_data_hash.call_args
+        assert call_kwargs.kwargs["client"] == mock_client
+        assert call_kwargs.kwargs["domain_hash"] == DOMAIN_HASH
+        assert call_kwargs.kwargs["message_hash"] == MESSAGE_HASH
+
+    @patch("src.wallets.trezor_1.get_transport")
+    def test_transport_exception_returns_none(self, mock_transport, capsys):
+        mock_transport.side_effect = TransportException("no device")
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Trezor device" in captured.out
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_address_mismatch_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = "0xwrongaddress"
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        mock_client.close.assert_called_once()
+        captured = capsys.readouterr()
+        assert "does not match" in captured.out
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_get_address_exception_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.side_effect = Exception("device error")
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        mock_client.close.assert_called_once()
+        captured = capsys.readouterr()
+        assert "An error occurred" in captured.out
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_sign_exception_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_typed_data_hash.side_effect = Exception("signing failed")
+
+        result = sign_typed_data_hash(0, SIGNER_ADDRESS, DOMAIN_HASH, MESSAGE_HASH)
+
+        assert result is None
+        mock_client.close.assert_called_once()
+        captured = capsys.readouterr()
+        assert "An error occurred" in captured.out
+
+
+class TestSignTransaction:
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_returns_attribute_dict(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_tx_eip1559.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is not None
+        assert hasattr(result, "raw_transaction")
+        assert hasattr(result, "hash")
+        assert hasattr(result, "r")
+        assert hasattr(result, "s")
+        assert hasattr(result, "v")
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_raw_transaction_eip1559_prefix(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_tx_eip1559.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result.raw_transaction.hex().startswith("0x02")
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_r_s_are_ints_v_is_original(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        v_val = 1
+        r_val = b"\x01" * 32
+        s_val = b"\x02" * 32
+        mock_eth.sign_tx_eip1559.return_value = (v_val, r_val, s_val)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert isinstance(result.r, int)
+        assert isinstance(result.s, int)
+        assert result.r == int.from_bytes(r_val, "big")
+        assert result.s == int.from_bytes(s_val, "big")
+        assert result.v == v_val
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_calls_close_on_success(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_tx_eip1559.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        mock_client.close.assert_called_once()
+
+    @patch("src.wallets.trezor_1.get_transport")
+    def test_transport_exception_returns_none(self, mock_transport, capsys):
+        mock_transport.side_effect = TransportException("no device")
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Trezor device" in captured.out
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_address_mismatch_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = "0xwrongaddress"
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        mock_client.close.assert_called_once()
+        captured = capsys.readouterr()
+        assert "does not match" in captured.out
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_get_address_exception_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.side_effect = Exception("device error")
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        mock_client.close.assert_called_once()
+        captured = capsys.readouterr()
+        assert "An error occurred" in captured.out
+
+    @patch("src.wallets.trezor_1.ClickUI")
+    @patch("src.wallets.trezor_1.TrezorClient")
+    @patch("src.wallets.trezor_1.get_transport")
+    @patch("src.wallets.trezor_1.ethereum")
+    def test_sign_tx_exception_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_tx_eip1559.side_effect = Exception("signing failed")
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        mock_client.close.assert_called_once()
+        captured = capsys.readouterr()
+        assert "An error occurred while signing transaction" in captured.out

--- a/transaction_signer/tests/test_trezor_t.py
+++ b/transaction_signer/tests/test_trezor_t.py
@@ -1,0 +1,289 @@
+from unittest.mock import MagicMock, patch
+
+from trezorlib.transport import TransportException
+from web3.datastructures import AttributeDict
+
+from helpers import HW_SIGNER_ADDRESS as SIGNER_ADDRESS
+from helpers import HW_UNSIGNED_TX as UNSIGNED_TX
+from src.wallets.trezor_t import get_path, sign_transaction, sign_typed_data
+
+
+class TestGetPath:
+    def test_index_zero(self):
+        assert get_path(0) == "m/44'/60'/0'/0/0"
+
+    def test_index_five(self):
+        assert get_path(5) == "m/44'/60'/0'/0/5"
+
+    def test_large_index(self):
+        assert get_path(999999) == "m/44'/60'/0'/0/999999"
+
+
+class TestSignTypedData:
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_returns_hex_signature(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_sig = MagicMock()
+        mock_sig.signature = b"\xab" * 65
+        mock_eth.sign_typed_data.return_value = mock_sig
+
+        result = sign_typed_data(0, SIGNER_ADDRESS, {"some": "data"})
+
+        assert result == (b"\xab" * 65).hex()
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_closes_client_on_success(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_sig = MagicMock()
+        mock_sig.signature = b"\xab" * 65
+        mock_eth.sign_typed_data.return_value = mock_sig
+
+        sign_typed_data(0, SIGNER_ADDRESS, {"some": "data"})
+
+        mock_client.close.assert_called_once()
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    @patch("src.wallets.trezor_t.parse_path")
+    def test_passes_correct_args(
+        self, mock_parse, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_sig = MagicMock()
+        mock_sig.signature = b"\xab" * 65
+        mock_eth.sign_typed_data.return_value = mock_sig
+        mock_parse.return_value = [44, 60, 0, 0, 3]
+        data = {"some": "data"}
+
+        sign_typed_data(3, SIGNER_ADDRESS, data)
+
+        mock_parse.assert_called_once_with("m/44'/60'/0'/0/3")
+        mock_eth.sign_typed_data.assert_called_once_with(
+            client=mock_client, n=[44, 60, 0, 0, 3], data=data
+        )
+
+    @patch("src.wallets.trezor_t.get_transport")
+    def test_transport_exception_returns_none(self, mock_transport, capsys):
+        mock_transport.side_effect = TransportException("No device")
+
+        result = sign_typed_data(0, SIGNER_ADDRESS, {"some": "data"})
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Trezor device" in captured.out
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_address_mismatch_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = "0xwrongaddress"
+
+        result = sign_typed_data(0, SIGNER_ADDRESS, {"some": "data"})
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "does not match" in captured.out
+        mock_client.close.assert_called_once()
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_get_address_exception_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.side_effect = Exception("Device error")
+
+        result = sign_typed_data(0, SIGNER_ADDRESS, {"some": "data"})
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "An error occurred" in captured.out
+        mock_client.close.assert_called_once()
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_sign_typed_data_exception_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_typed_data.side_effect = Exception("Signing failed")
+
+        result = sign_typed_data(0, SIGNER_ADDRESS, {"some": "data"})
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "An error occurred" in captured.out
+        mock_client.close.assert_called_once()
+
+
+class TestSignTransaction:
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_returns_attribute_dict(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_tx_eip1559.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert isinstance(result, AttributeDict)
+        assert "raw_transaction" in result
+        assert "hash" in result
+        assert "r" in result
+        assert "s" in result
+        assert "v" in result
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_raw_transaction_eip1559_prefix(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_tx_eip1559.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result.raw_transaction.hex().startswith("0x02")
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_r_s_are_ints_v_is_original(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        v_val = 1
+        r_val = b"\x01" * 32
+        s_val = b"\x02" * 32
+        mock_eth.sign_tx_eip1559.return_value = (v_val, r_val, s_val)
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert isinstance(result.r, int)
+        assert isinstance(result.s, int)
+        assert result.r == int.from_bytes(r_val, "big")
+        assert result.s == int.from_bytes(s_val, "big")
+        assert result.v == v_val
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_closes_client_on_success(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_tx_eip1559.return_value = (1, b"\x01" * 32, b"\x02" * 32)
+
+        sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        mock_client.close.assert_called_once()
+
+    @patch("src.wallets.trezor_t.get_transport")
+    def test_transport_exception_returns_none(self, mock_transport, capsys):
+        mock_transport.side_effect = TransportException("No device")
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "Error communicating with Trezor device" in captured.out
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_address_mismatch_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = "0xwrongaddress"
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "does not match" in captured.out
+        mock_client.close.assert_called_once()
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_get_address_exception_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.side_effect = Exception("Device error")
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "An error occurred" in captured.out
+        mock_client.close.assert_called_once()
+
+    @patch("src.wallets.trezor_t.ClickUI")
+    @patch("src.wallets.trezor_t.TrezorClient")
+    @patch("src.wallets.trezor_t.get_transport")
+    @patch("src.wallets.trezor_t.ethereum")
+    def test_sign_tx_exception_returns_none(
+        self, mock_eth, mock_transport, mock_client_cls, mock_ui, capsys
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_eth.get_address.return_value = SIGNER_ADDRESS
+        mock_eth.sign_tx_eip1559.side_effect = Exception("Signing failed")
+
+        result = sign_transaction(0, SIGNER_ADDRESS, UNSIGNED_TX)
+
+        assert result is None
+        captured = capsys.readouterr()
+        assert "An error occurred while signing transaction" in captured.out
+        mock_client.close.assert_called_once()

--- a/transaction_signer/tests/test_user_input.py
+++ b/transaction_signer/tests/test_user_input.py
@@ -1,0 +1,182 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.user_input import get_chain, get_relayer, get_safe, get_signer
+
+CHAINS = [
+    {"name": "Base", "chain_id": 8453, "rpc_name": "RPC_BASE"},
+    {"name": "Optimism", "chain_id": 10, "rpc_name": "RPC_OPTIMISM"},
+]
+
+SAFES = [
+    {"name": "Safe A", "address": "0x1111111111111111111111111111111111111111"},
+    {"name": "Safe B", "address": "0x2222222222222222222222222222222222222222"},
+]
+
+SIGNERS = [
+    {"name": "Signer A", "address": "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+    {"name": "Signer B", "address": "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"},
+]
+
+RELAYERS = [
+    {"name": "Relayer A", "address": "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"},
+    {"name": "Relayer B", "address": "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"},
+]
+
+
+class TestGetChain:
+    @patch("src.user_input.inquirer.prompt")
+    def test_selects_first_chain(self, mock_prompt):
+        mock_prompt.return_value = {"chains": "Base (Chain Id: 8453)"}
+        result = get_chain(CHAINS)
+        assert result == CHAINS[0]
+        assert result["chain_id"] == 8453
+
+    @patch("src.user_input.inquirer.prompt")
+    def test_selects_second_chain(self, mock_prompt):
+        mock_prompt.return_value = {"chains": "Optimism (Chain Id: 10)"}
+        result = get_chain(CHAINS)
+        assert result == CHAINS[1]
+        assert result["rpc_name"] == "RPC_OPTIMISM"
+
+    @patch("src.user_input.inquirer.prompt")
+    def test_parses_chain_id_from_formatted_string(self, mock_prompt):
+        mock_prompt.return_value = {"chains": "Some Chain (Chain Id: 42161)"}
+        chains = [{"name": "Some Chain", "chain_id": 42161, "rpc_name": "RPC_ARB"}]
+        result = get_chain(chains)
+        assert result["chain_id"] == 42161
+
+
+class TestGetSafe:
+    @patch("src.user_input.inquirer.prompt")
+    def test_selects_safe_by_address(self, mock_prompt):
+        mock_prompt.return_value = {
+            "safes": "Safe A (0x1111111111111111111111111111111111111111)"
+        }
+        result = get_safe(SAFES)
+        assert result == SAFES[0]
+
+    @patch("src.user_input.inquirer.prompt")
+    def test_selects_second_safe(self, mock_prompt):
+        mock_prompt.return_value = {
+            "safes": "Safe B (0x2222222222222222222222222222222222222222)"
+        }
+        result = get_safe(SAFES)
+        assert result == SAFES[1]
+
+
+class TestGetSigner:
+    @patch("src.user_input.inquirer.prompt")
+    def test_selects_signer(self, mock_prompt):
+        mock_prompt.return_value = {
+            "signers": "Signer A (0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)"
+        }
+        result = get_signer(SIGNERS)
+        assert result == SIGNERS[0]
+
+    @patch("src.user_input.inquirer.prompt")
+    def test_back_returns_false(self, mock_prompt):
+        mock_prompt.return_value = {"signers": "Back"}
+        result = get_signer(SIGNERS)
+        assert result is False
+
+    @patch("src.user_input.inquirer.prompt")
+    def test_choices_include_back(self, mock_prompt):
+        mock_prompt.return_value = {"signers": "Back"}
+        get_signer(SIGNERS)
+        call_args = mock_prompt.call_args[0][0]
+        choices = call_args[0].choices
+        assert "Back" in choices
+        assert len(choices) == len(SIGNERS) + 1
+
+
+class TestGetRelayer:
+    @patch("src.user_input.inquirer.prompt")
+    def test_selects_relayer(self, mock_prompt):
+        mock_prompt.return_value = {
+            "relayers": "Relayer B (0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD)"
+        }
+        result = get_relayer(RELAYERS)
+        assert result == RELAYERS[1]
+
+    @patch("src.user_input.inquirer.prompt")
+    def test_back_returns_false(self, mock_prompt):
+        mock_prompt.return_value = {"relayers": "Back"}
+        result = get_relayer(RELAYERS)
+        assert result is False
+
+    @patch("src.user_input.inquirer.prompt")
+    def test_choices_include_back(self, mock_prompt):
+        mock_prompt.return_value = {"relayers": "Back"}
+        get_relayer(RELAYERS)
+        call_args = mock_prompt.call_args[0][0]
+        choices = call_args[0].choices
+        assert "Back" in choices
+        assert len(choices) == len(RELAYERS) + 1
+
+
+class TestGetChainMalformedResponse:
+    @patch("src.user_input.inquirer.prompt")
+    def test_missing_chain_id_format_raises(self, mock_prompt):
+        mock_prompt.return_value = {"chains": "Base"}
+        with pytest.raises(IndexError):
+            get_chain(CHAINS)
+
+
+class TestGetChainNoMatch:
+    @patch("src.user_input.inquirer.prompt")
+    def test_unmatched_chain_id_raises(self, mock_prompt):
+        mock_prompt.return_value = {"chains": "Fake (Chain Id: 99999)"}
+        with pytest.raises(ValueError):
+            get_chain(CHAINS)
+
+
+class TestGetSafeNoMatch:
+    @patch("src.user_input.inquirer.prompt")
+    def test_unmatched_address_raises(self, mock_prompt):
+        mock_prompt.return_value = {
+            "safes": "Unknown (0x0000000000000000000000000000000000000000)"
+        }
+        with pytest.raises(ValueError):
+            get_safe(SAFES)
+
+
+class TestGetSignerNoMatch:
+    @patch("src.user_input.inquirer.prompt")
+    def test_unmatched_address_raises(self, mock_prompt):
+        mock_prompt.return_value = {
+            "signers": "Unknown (0x0000000000000000000000000000000000000000)"
+        }
+        with pytest.raises(ValueError):
+            get_signer(SIGNERS)
+
+
+class TestGetRelayerNoMatch:
+    @patch("src.user_input.inquirer.prompt")
+    def test_unmatched_address_raises(self, mock_prompt):
+        mock_prompt.return_value = {
+            "relayers": "Unknown (0x0000000000000000000000000000000000000000)"
+        }
+        with pytest.raises(ValueError):
+            get_relayer(RELAYERS)
+
+
+class TestGetChainSingleItem:
+    @patch("src.user_input.inquirer.prompt")
+    def test_single_chain(self, mock_prompt):
+        single = [CHAINS[0]]
+        mock_prompt.return_value = {"chains": "Base (Chain Id: 8453)"}
+        result = get_chain(single)
+        assert result == single[0]
+
+
+class TestGetSafeSingleItem:
+    @patch("src.user_input.inquirer.prompt")
+    def test_single_safe(self, mock_prompt):
+        single = [SAFES[0]]
+        mock_prompt.return_value = {
+            "safes": "Safe A (0x1111111111111111111111111111111111111111)"
+        }
+        result = get_safe(single)
+        assert result == single[0]

--- a/transaction_signer/tests/test_validate_config.py
+++ b/transaction_signer/tests/test_validate_config.py
@@ -1,0 +1,228 @@
+import pytest
+
+from helpers import MULTISEND_ADDRESS
+from src.utils.validate_config import validate
+
+VALID_SAFES = [
+    {"name": "Test Safe", "address": "0x1111111111111111111111111111111111111111"}
+]
+VALID_SIGNERS = [
+    {
+        "name": "Signer One",
+        "address": "0x2222222222222222222222222222222222222222",
+        "wallet": "T",
+        "index": 0,
+    }
+]
+VALID_RELAYERS = [
+    {
+        "name": "Relayer One",
+        "address": "0x3333333333333333333333333333333333333333",
+        "wallet": "HOT",
+        "key_name": "KEY_TEST",
+    }
+]
+VALID_CHAINS = [
+    {"name": "Base", "chain_id": 8453},
+]
+
+
+class TestValidateConfigHappyPath:
+    def test_valid_call(self):
+        validate(VALID_SAFES, VALID_SIGNERS, VALID_RELAYERS, 0, "0x1234")
+
+    def test_valid_delegatecall(self):
+        validate(VALID_SAFES, VALID_SIGNERS, VALID_RELAYERS, 1, MULTISEND_ADDRESS)
+
+    def test_valid_with_chains(self):
+        validate(
+            VALID_SAFES,
+            VALID_SIGNERS,
+            VALID_RELAYERS,
+            0,
+            "0x1234",
+            chains=VALID_CHAINS,
+        )
+
+
+class TestValidateConfigOperation:
+    def test_invalid_operation(self):
+        with pytest.raises(Exception, match="Operation must be 0 or 1"):
+            validate(VALID_SAFES, VALID_SIGNERS, VALID_RELAYERS, 2, "0x1234")
+
+    def test_delegatecall_wrong_to(self):
+        with pytest.raises(Exception, match="Inconsistent input"):
+            validate(
+                VALID_SAFES,
+                VALID_SIGNERS,
+                VALID_RELAYERS,
+                1,
+                "0x0000000000000000000000000000000000000001",
+            )
+
+
+class TestValidateConfigNames:
+    def test_safe_name_with_parens(self):
+        bad_safes = [{"name": "Owner (main)", "address": "0x1234"}]
+        with pytest.raises(Exception, match="can't contain"):
+            validate(bad_safes, VALID_SIGNERS, VALID_RELAYERS, 0, "0x1234")
+
+    def test_signer_name_with_parens(self):
+        bad_signers = [
+            {
+                "name": "Signer (bad)",
+                "address": "0x4444444444444444444444444444444444444444",
+                "wallet": "T",
+                "index": 0,
+            }
+        ]
+        with pytest.raises(Exception, match="can't contain"):
+            validate(VALID_SAFES, bad_signers, VALID_RELAYERS, 0, "0x1234")
+
+    def test_relayer_name_with_parens(self):
+        bad_relayers = [
+            {
+                "name": "Relayer (bad)",
+                "address": "0x3333333333333333333333333333333333333333",
+                "wallet": "HOT",
+                "key_name": "KEY_TEST",
+            }
+        ]
+        with pytest.raises(Exception, match="can't contain"):
+            validate(VALID_SAFES, VALID_SIGNERS, bad_relayers, 0, "0x1234")
+
+    def test_chain_name_with_parens(self):
+        bad_chains = [{"name": "Base (mainnet)", "chain_id": 8453}]
+        with pytest.raises(Exception, match="can't contain"):
+            validate(
+                VALID_SAFES,
+                VALID_SIGNERS,
+                VALID_RELAYERS,
+                0,
+                "0x1234",
+                chains=bad_chains,
+            )
+
+
+class TestValidateConfigUniqueness:
+    def test_duplicate_signer_addresses(self):
+        dup_signers = [
+            {"name": "Signer A", "address": "0xABC", "wallet": "T", "index": 0},
+            {"name": "Signer B", "address": "0xABC", "wallet": "T", "index": 1},
+        ]
+        with pytest.raises(Exception, match="signing addresses must be unique"):
+            validate(VALID_SAFES, dup_signers, VALID_RELAYERS, 0, "0x1234")
+
+    def test_duplicate_relayer_addresses(self):
+        dup_relayers = [
+            {"name": "Relayer A", "address": "0xABC", "wallet": "HOT", "key_name": "A"},
+            {"name": "Relayer B", "address": "0xABC", "wallet": "HOT", "key_name": "B"},
+        ]
+        with pytest.raises(Exception, match="relayer addresses must be unique"):
+            validate(VALID_SAFES, VALID_SIGNERS, dup_relayers, 0, "0x1234")
+
+
+class TestValidateConfigWalletTypes:
+    def test_invalid_signer_wallet_type(self):
+        bad_signers = [
+            {
+                "name": "Signer Bad",
+                "address": "0x5555555555555555555555555555555555555555",
+                "wallet": "INVALID",
+                "index": 0,
+            }
+        ]
+        with pytest.raises(Exception, match="Invalid wallet type"):
+            validate(VALID_SAFES, bad_signers, VALID_RELAYERS, 0, "0x1234")
+
+    def test_invalid_relayer_wallet_type(self):
+        bad_relayers = [
+            {
+                "name": "Relayer Bad",
+                "address": "0x6666666666666666666666666666666666666666",
+                "wallet": "X",
+                "key_name": "KEY",
+            }
+        ]
+        with pytest.raises(Exception, match="Invalid wallet type"):
+            validate(VALID_SAFES, VALID_SIGNERS, bad_relayers, 0, "0x1234")
+
+    def test_missing_wallet_type_on_signer(self):
+        bad_signers = [
+            {
+                "name": "No Wallet",
+                "address": "0x7777777777777777777777777777777777777777",
+                "index": 0,
+            }
+        ]
+        with pytest.raises(Exception, match="Invalid wallet type"):
+            validate(VALID_SAFES, bad_signers, VALID_RELAYERS, 0, "0x1234")
+
+    def test_all_valid_wallet_types_accepted(self):
+        for wtype in ["HOT", "T", "1", "L"]:
+            extra = {"key_name": "K"} if wtype == "HOT" else {"index": 0}
+            signers = [
+                {
+                    "name": f"Signer {wtype}",
+                    "address": "0x2222222222222222222222222222222222222222",
+                    "wallet": wtype,
+                    **extra,
+                }
+            ]
+            validate(VALID_SAFES, signers, VALID_RELAYERS, 0, "0x1234")
+
+
+class TestValidateConfigWalletFields:
+    def test_hot_wallet_missing_key_name(self):
+        bad_signers = [
+            {
+                "name": "Hot No Key",
+                "address": "0x8888888888888888888888888888888888888888",
+                "wallet": "HOT",
+                "index": 0,
+            }
+        ]
+        with pytest.raises(Exception, match="must have a 'key_name' field"):
+            validate(VALID_SAFES, bad_signers, VALID_RELAYERS, 0, "0x1234")
+
+    def test_hardware_wallet_missing_index(self):
+        bad_signers = [
+            {
+                "name": "Trezor No Index",
+                "address": "0x9999999999999999999999999999999999999999",
+                "wallet": "T",
+            }
+        ]
+        with pytest.raises(Exception, match="must have an 'index' field"):
+            validate(VALID_SAFES, bad_signers, VALID_RELAYERS, 0, "0x1234")
+
+    def test_ledger_signer_missing_index(self):
+        bad_signers = [
+            {
+                "name": "Ledger No Index",
+                "address": "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "wallet": "L",
+            }
+        ]
+        with pytest.raises(Exception, match="must have an 'index' field"):
+            validate(VALID_SAFES, bad_signers, VALID_RELAYERS, 0, "0x1234")
+
+
+class TestValidateConfigEmptyLists:
+    def test_empty_safes_passes(self):
+        validate([], VALID_SIGNERS, VALID_RELAYERS, 0, "0x1234")
+
+    def test_empty_signers_passes(self):
+        validate(VALID_SAFES, [], VALID_RELAYERS, 0, "0x1234")
+
+    def test_empty_relayers_passes(self):
+        validate(VALID_SAFES, VALID_SIGNERS, [], 0, "0x1234")
+
+
+class TestValidateConfigOperationBoundary:
+    def test_negative_operation_raises(self):
+        with pytest.raises(Exception, match="Operation must be 0 or 1"):
+            validate(VALID_SAFES, VALID_SIGNERS, VALID_RELAYERS, -1, "0x1234")
+
+    def test_operation_0_with_multisend_address_allowed(self):
+        validate(VALID_SAFES, VALID_SIGNERS, VALID_RELAYERS, 0, MULTISEND_ADDRESS)

--- a/transaction_signer/tests/test_validate_signer.py
+++ b/transaction_signer/tests/test_validate_signer.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from helpers import make_mock_safe
+from src.utils.validate_signer import validate
+
+SIGNER = {"name": "Signer One", "address": "0x2222222222222222222222222222222222222222"}
+TX_HASH = "abc123"
+
+
+class TestValidateSignerIsOwnerNoExistingSig:
+    def test_returns_true(self):
+        safe = make_mock_safe(is_owner=True)
+        all_signatures = {}
+        assert validate(safe, all_signatures, TX_HASH, SIGNER) is True
+
+    def test_returns_true_when_hash_exists_but_signer_not_in_it(self):
+        safe = make_mock_safe(is_owner=True)
+        all_signatures = {TX_HASH: {"0xOtherAddress": "some_sig"}}
+        assert validate(safe, all_signatures, TX_HASH, SIGNER) is True
+
+
+class TestValidateSignerIsOwnerExistingSig:
+    @patch("src.utils.validate_signer.inquirer.prompt")
+    def test_overwrite_yes_returns_true(self, mock_prompt):
+        mock_prompt.return_value = {"overwrite signature": "Yes"}
+        safe = make_mock_safe(is_owner=True)
+        all_signatures = {TX_HASH: {SIGNER["address"]: "existing_sig"}}
+        assert validate(safe, all_signatures, TX_HASH, SIGNER) is True
+
+    @patch("src.utils.validate_signer.inquirer.prompt")
+    def test_overwrite_no_returns_false(self, mock_prompt):
+        mock_prompt.return_value = {"overwrite signature": "No"}
+        safe = make_mock_safe(is_owner=True)
+        all_signatures = {TX_HASH: {SIGNER["address"]: "existing_sig"}}
+        assert validate(safe, all_signatures, TX_HASH, SIGNER) is False
+
+
+class TestValidateSignerNotOwner:
+    def test_returns_false(self):
+        safe = make_mock_safe(is_owner=False)
+        assert validate(safe, {}, TX_HASH, SIGNER) is False
+
+    def test_prints_error_message(self, capsys):
+        safe = make_mock_safe(is_owner=False)
+        validate(safe, {}, TX_HASH, SIGNER)
+        captured = capsys.readouterr()
+        assert "is not an owner" in captured.out
+        assert SIGNER["address"] in captured.out
+
+
+class TestValidateSignerEdgeCases:
+    def test_empty_string_signature_treated_as_no_existing(self):
+        safe = make_mock_safe(is_owner=True)
+        all_signatures = {TX_HASH: {SIGNER["address"]: ""}}
+        assert validate(safe, all_signatures, TX_HASH, SIGNER) is True
+
+    def test_is_owner_rpc_failure_propagates(self):
+        safe = MagicMock()
+        safe.functions.isOwner.return_value.call.side_effect = Exception("RPC error")
+        with pytest.raises(Exception, match="RPC error"):
+            validate(safe, {}, TX_HASH, SIGNER)
+
+    def test_different_tx_hash_no_collision(self):
+        safe = make_mock_safe(is_owner=True)
+        all_signatures = {"other_hash": {SIGNER["address"]: "existing_sig"}}
+        assert validate(safe, all_signatures, TX_HASH, SIGNER) is True


### PR DESCRIPTION
## Summary
- Add `sign_transaction` support for Ledger Nano, enabling Ledger as a relayer
- Strengthen config validation (wallet types, required fields, chain names)
- Add comprehensive hardware wallet test suites (Trezor T, Trezor 1, Ledger Nano) and full test coverage across all modules (214 tests)

## Test plan
- [x] All 214 tests passing
- [x] Ruff lint: 0 errors
- [x] Ruff format: 0 issues