### PR TITLE
Guard device close calls in error handlers

### DIFF
--- a/transaction_signer/src/wallets/ledger_nano.py
+++ b/transaction_signer/src/wallets/ledger_nano.py
@@ -42,11 +42,11 @@ def sign_typed_data_hash(
             )
             return None
     except CommException as e:
-        dongle.close()
+        _safe_close(dongle)
         print(f"Error communicating with Ledger device: {e}")
         return None
     except Exception as e:
-        dongle.close()
+        _safe_close(dongle)
         print(f"Unexpected error: {e}")
         return None
 
@@ -60,11 +60,11 @@ def sign_typed_data_hash(
         dongle.close()
         return signature.hex()
     except CommException as e:
-        dongle.close()
+        _safe_close(dongle)
         print(f"Error communicating with Ledger device: {e}")
         return None
     except Exception as e:
-        dongle.close()
+        _safe_close(dongle)
         print(f"Unexpected error: {e}")
         return None
 
@@ -102,11 +102,11 @@ def sign_transaction(
             )
             return None
     except CommException as e:
-        dongle.close()
+        _safe_close(dongle)
         print(f"Error communicating with Ledger device: {e}")
         return None
     except Exception as e:
-        dongle.close()
+        _safe_close(dongle)
         print(f"Unexpected error: {e}")
         return None
 
@@ -148,13 +148,20 @@ def sign_transaction(
         )
         return signed_tx
     except CommException as e:
-        dongle.close()
+        _safe_close(dongle)
         print(f"Error communicating with Ledger device: {e}")
         return None
     except Exception as e:
-        dongle.close()
+        _safe_close(dongle)
         print(f"Unexpected error: {e}")
         return None
+
+
+def _safe_close(device):
+    try:
+        device.close()
+    except Exception:
+        pass
 
 
 def get_path(index: int) -> str:

--- a/transaction_signer/src/wallets/trezor_1.py
+++ b/transaction_signer/src/wallets/trezor_1.py
@@ -44,7 +44,7 @@ def sign_typed_data_hash(
             )
             return None
     except Exception as e:
-        client.close()
+        _safe_close(client)
         print(f"An error occurred: {e}")
         return None
 
@@ -59,7 +59,7 @@ def sign_typed_data_hash(
         client.close()
         return signature.signature.hex()
     except Exception as e:
-        client.close()
+        _safe_close(client)
         print(f"An error occurred: {e}")
         return None
 
@@ -97,7 +97,7 @@ def sign_transaction(
             )
             return None
     except Exception as e:
-        client.close()
+        _safe_close(client)
         print(f"An error occurred: {e}")
         return None
 
@@ -150,9 +150,16 @@ def sign_transaction(
         )
         return signed_tx
     except Exception as e:
-        client.close()
+        _safe_close(client)
         print(f"An error occurred while signing transaction: {e}")
         return None
+
+
+def _safe_close(client: TrezorClient):
+    try:
+        client.close()
+    except Exception:
+        pass
 
 
 def get_path(index: int) -> str:

--- a/transaction_signer/src/wallets/trezor_t.py
+++ b/transaction_signer/src/wallets/trezor_t.py
@@ -41,7 +41,7 @@ def sign_typed_data(signer_index: int, signer_address: str, data: dict) -> str:
             )
             return None
     except Exception as e:
-        client.close()
+        _safe_close(client)
         print(f"An error occurred: {e}")
         return None
 
@@ -51,7 +51,7 @@ def sign_typed_data(signer_index: int, signer_address: str, data: dict) -> str:
         client.close()
         return signature.signature.hex()
     except Exception as e:
-        client.close()
+        _safe_close(client)
         print(f"An error occurred: {e}")
         return None
 
@@ -89,7 +89,7 @@ def sign_transaction(
             )
             return None
     except Exception as e:
-        client.close()
+        _safe_close(client)
         print(f"An error occurred: {e}")
         return None
 
@@ -142,9 +142,16 @@ def sign_transaction(
         )
         return signed_tx
     except Exception as e:
-        client.close()
+        _safe_close(client)
         print(f"An error occurred while signing transaction: {e}")
         return None
+
+
+def _safe_close(client: TrezorClient):
+    try:
+        client.close()
+    except Exception:
+        pass
 
 
 def get_path(index: int) -> str:


### PR DESCRIPTION
## Summary
- Wraps `client.close()` / `dongle.close()` in except blocks with a `_safe_close()` helper
- Prevents unhandled crash when trezorlib or ledgerblue internal error handling already closed the device session before our except block runs
- Affects trezor_t.py, trezor_1.py, and ledger_nano.py

## Context
When the Trezor Bridge session expires mid-signing (e.g. long confirmation on large multicall calldata), trezorlib's internal error handler calls `client.close()` which also fails. Our except block then calls `client.close()` again, causing a second unhandled `BridgeException` that crashes the script instead of printing the error gracefully.

## Test plan
- [x] All 218 tests pass
- [x] Ruff check and format clean
- [x] Verify with actual Trezor device session timeout scenario